### PR TITLE
Add transactional auth emails and complete the email/password auth flow

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -18,6 +18,8 @@ FACEBOOK_CLIENT_SECRET=your_facebook_app_secret_here
 
 # Resend Email API
 RESEND_API_KEY=re_your_resend_api_key_here
+# Sender for transactional emails. Must exactly match a verified Resend domain.
+EMAIL_FROM=Disscount <noreply@disscount.me>
 
 # Cijene API Configuration
 CIJENE_API_URL=https://api.cijene.dev

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "email": "email dev --dir src/emails"
   },
   "dependencies": {
     "@daveyplate/better-auth-ui": "^3.2.13",
@@ -42,9 +43,11 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-email": "^6.6.3",
     "react-hook-form": "^7.68.0",
     "react-scan": "^0.4.3",
     "recharts": "2.15.4",
+    "resend": "^6.14.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "zod": "^4.1.13"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      react-email:
+        specifier: ^6.6.3
+        version: 6.6.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-hook-form:
         specifier: ^7.68.0
         version: 7.80.0(react@19.2.4)
@@ -118,6 +121,9 @@ importers:
       recharts:
         specifier: 2.15.4
         version: 2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      resend:
+        specifier: ^6.14.0
+        version: 6.14.0(@react-email/render@2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -133,7 +139,7 @@ importers:
         version: 3.3.5
       '@openapitools/openapi-generator-cli':
         specifier: ^2.25.2
-        version: 2.38.0
+        version: 2.39.0
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.3.1
@@ -230,6 +236,11 @@ packages:
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/parser@7.27.0':
+    resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
@@ -241,6 +252,10 @@ packages:
 
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.27.0':
+    resolution: {integrity: sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.29.7':
@@ -1197,8 +1212,8 @@ packages:
       axios: ^1.3.1
       rxjs: ^7.0.0
 
-  '@nestjs/common@11.1.26':
-    resolution: {integrity: sha512-0VARQyzuGbprvjO+slWq9Jtj1P0jYCSKAUSv9LWFNWD39ZbDzXXM1pMs35kReVXwchra0urMfTQxw4uAOfdSzA==}
+  '@nestjs/common@11.1.27':
+    resolution: {integrity: sha512-kEGSzqM2lWr4whh4Ubflw+oPZSEzxvRMu9WL+LveZploJWTjec5bBlCiRVlVzTPg2kIwBiLwWSvCCW7Wnin1gg==}
     peerDependencies:
       class-transformer: '>=0.4.1'
       class-validator: '>=0.13.2'
@@ -1210,8 +1225,8 @@ packages:
       class-validator:
         optional: true
 
-  '@nestjs/core@11.1.26':
-    resolution: {integrity: sha512-K45zUwYpowEsVqm8qNIzsMcl4LJev0MK9zVhDnmym7YRTJ2/caslqVeKYhPRd5+Fh81IkvWUVu6vEo46uZ5mgQ==}
+  '@nestjs/core@11.1.27':
+    resolution: {integrity: sha512-K6DX7hcqmZdeXkv7tsPakKBRCgqL19a4mtbX4FluY0hWtFdtPKp6lbe+lb8gWPfvLdbOWr/CPScn7BSjBX+Ecg==}
     engines: {node: '>= 20'}
     peerDependencies:
       '@nestjs/common': ^11.0.0
@@ -1315,8 +1330,8 @@ packages:
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
     hasBin: true
 
-  '@openapitools/openapi-generator-cli@2.38.0':
-    resolution: {integrity: sha512-A2ZSRX1gyPhMRzD/1Rn4qpBxDQrDBF4BDMIEkfAwpeZbhaOeWXhudvgeI2GlHCswHubHtLxmGeTubNf7wTgmJQ==}
+  '@openapitools/openapi-generator-cli@2.39.0':
+    resolution: {integrity: sha512-AKFn02Jvzrh/suDt3SipgtjwvNvT/pUu3hr5PMwcHbwW3XkQfmT27+DWak7rgsnKYBQwVP4D/lSFT+eBI7W2/w==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -2187,6 +2202,13 @@ packages:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
 
+  '@react-email/render@2.0.9':
+    resolution: {integrity: sha512-M89LiXy2q+9tmQ4VMR0rYGuEe6NJ6HhZsSxBMoLwIia5fVOLcZQcZe2GEO0nAkLZspDjEhn7mtMRPmeMKECEdQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
   '@react-email/row@0.0.13':
     resolution: {integrity: sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw==}
     engines: {node: '>=20.0.0'}
@@ -2268,6 +2290,12 @@ packages:
   '@simplewebauthn/server@13.3.1':
     resolution: {integrity: sha512-GV/oM/qeycWn8p42JZIMJBsXWQcNFg+nJFzeQTnMA4gN8mXg0+HZFWJerHg8ZN/zlveMS3iV1wzuFpOVWS/46w==}
     engines: {node: '>=20.0.0'}
+
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2437,6 +2465,9 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -2503,6 +2534,9 @@ packages:
 
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.61.1':
     resolution: {integrity: sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==}
@@ -2700,6 +2734,10 @@ packages:
       react: ^17 || ^18 || ^19
       react-dom: ^17 || ^18 || ^19
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2718,8 +2756,19 @@ packages:
     resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
     engines: {node: '>= 20'}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -2802,6 +2851,9 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  atomically@2.1.1:
+    resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -2826,6 +2878,10 @@ packages:
 
   barcode-detector@3.2.0:
     resolution: {integrity: sha512-MrT5TT058ptG5YB157pHLfXKVpp0BKEfQBOb8QvzTbatzmLDu85JJ0Gd/sCYwbwdwStJvxsYflrSN6D6E4Ndyw==}
+
+  base64id@2.0.0:
+    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
+    engines: {node: ^4.5.0 || >= 5.9}
 
   baseline-browser-mapping@2.10.38:
     resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
@@ -2968,6 +3024,13 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -3014,6 +3077,10 @@ packages:
   comlink@4.4.2:
     resolution: {integrity: sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==}
 
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
@@ -3029,6 +3096,10 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
+  conf@15.1.0:
+    resolution: {integrity: sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==}
+    engines: {node: '>=20'}
+
   consola@2.15.3:
     resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
 
@@ -3039,6 +3110,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   copy-anything@4.0.5:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
@@ -3046,9 +3121,17 @@ packages:
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
 
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -3115,6 +3198,14 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  debounce-fn@6.0.0:
+    resolution: {integrity: sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==}
+    engines: {node: '>=18'}
+
+  debounce@2.2.0:
+    resolution: {integrity: sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==}
+    engines: {node: '>=18'}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -3193,6 +3284,10 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dot-prop@10.1.0:
+    resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
+    engines: {node: '>=20'}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -3316,6 +3411,14 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
+
+  engine.io@6.6.9:
+    resolution: {integrity: sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==}
+    engines: {node: '>=10.2.0'}
+
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
@@ -3323,6 +3426,10 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   es-abstract-get@1.0.0:
     resolution: {integrity: sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==}
@@ -3554,6 +3661,12 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -3698,6 +3811,10 @@ packages:
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
+
+  globals@11.12.0:
+    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
+    engines: {node: '>=4'}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -3909,6 +4026,10 @@ packages:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -3939,6 +4060,10 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  jiti@2.4.2:
+    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+    hasBin: true
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -3964,6 +4089,12 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -3985,6 +4116,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -4096,6 +4231,10 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
+    engines: {node: '>=18'}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -4128,6 +4267,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -4140,9 +4282,21 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -4193,13 +4347,13 @@ packages:
     resolution: {integrity: sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  nanoid@3.3.13:
-    resolution: {integrity: sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==}
+  nanoid@3.3.14:
+    resolution: {integrity: sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.14:
-    resolution: {integrity: sha512-5c8l8kVzqpnDPaicbEop/fV0Q1w16FmbWtVhMqugTozAwYdlIQojWH5a/M7UfziFmGdQRrUdV+EPzc9Xng3VAQ==}
+  nanoid@5.1.15:
+    resolution: {integrity: sha512-kBg3RpGtIe+RpTbyXwoI6pk5yD7KUiI3sygUqgeBMRst42KmhB4RZC7eiO9Wa1HIpaCCtpE2DJ6OI4Wi5ebwFw==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -4214,6 +4368,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
 
   netmask@2.1.1:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
@@ -4256,6 +4414,15 @@ packages:
   node-releases@2.0.48:
     resolution: {integrity: sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==}
     engines: {node: '>=18'}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  nypm@0.6.6:
+    resolution: {integrity: sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -4340,6 +4507,9 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
@@ -4388,6 +4558,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  picospinner@3.0.0:
+    resolution: {integrity: sha512-lGA1TNsmy2bxvRsTI2cV01kfTwKzZjnZSDmF9llYNyMHMrU4sP87lQ5taiIKm88L3cbswjl008nwyGc3WpNvzg==}
+    engines: {node: '>=18.0.0'}
+
   playwright-core@1.61.0:
     resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
     engines: {node: '>=18'}
@@ -4401,6 +4575,9 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -4441,6 +4618,10 @@ packages:
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
+
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -4504,6 +4685,14 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-email@6.6.3:
+    resolution: {integrity: sha512-kYpkIh00X771MQ4JDKX1Exqj+gRUeNPp/44oHSpo3zvUjnieatpNUu5ssF+me/Ure89J6E6I61ybcr131XDOMw==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
 
   react-google-recaptcha@3.1.0:
     resolution: {integrity: sha512-cYW2/DWas8nEKZGD7SCu9BSuVz8iOcOLHChHyi7upUuVhkpkhYG/6N3KDiTQ3XAiZ2UAZkfvYKMfAHOzBOcGEg==}
@@ -4593,6 +4782,10 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   recharts-scale@0.4.5:
     resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
 
@@ -4614,6 +4807,19 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resend@6.14.0:
+    resolution: {integrity: sha512-jVdpUgOoWGLjaP64lo8KwzHT9gY4w6Dl8c36CIb2F+ayYOMLr3khqs8xrNjXM2k19b+lPoj0VWQFhVNLiToBjA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -4732,6 +4938,17 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
+  socket.io-adapter@2.5.8:
+    resolution: {integrity: sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==}
+
+  socket.io-parser@4.2.6:
+    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io@4.8.3:
+    resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
+    engines: {node: '>=10.2.0'}
+
   socks-proxy-agent@10.1.0:
     resolution: {integrity: sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==}
     engines: {node: '>= 20'}
@@ -4766,6 +4983,9 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -4822,6 +5042,12 @@ packages:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
 
+  stubborn-fs@2.0.0:
+    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
+
+  stubborn-utils@1.0.2:
+    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -4868,6 +5094,10 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -4895,6 +5125,10 @@ packages:
 
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
+
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -5016,6 +5250,10 @@ packages:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
   vaul@1.1.2:
     resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
     peerDependencies:
@@ -5046,6 +5284,9 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  when-exit@2.1.5:
+    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -5080,6 +5321,18 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -5102,6 +5355,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -5194,6 +5451,10 @@ snapshots:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
 
+  '@babel/parser@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
@@ -5205,6 +5466,18 @@ snapshots:
       '@babel/code-frame': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
+
+  '@babel/traverse@7.27.0':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.27.0
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/traverse@7.29.7':
     dependencies:
@@ -5925,13 +6198,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@nestjs/axios@4.0.1(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.18.0)(rxjs@7.8.2)':
+  '@nestjs/axios@4.0.1(@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.18.0)(rxjs@7.8.2)':
     dependencies:
-      '@nestjs/common': 11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)
       axios: 1.18.0
       rxjs: 7.8.2
 
-  '@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
       file-type: 21.3.4
       iterare: 1.2.1
@@ -5943,9 +6216,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/core@11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)':
+  '@nestjs/core@11.1.27(@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)':
     dependencies:
-      '@nestjs/common': 11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)
       fast-safe-stringify: 2.1.1
       iterare: 1.2.1
       path-to-regexp: 8.4.2
@@ -6010,12 +6283,12 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@openapitools/openapi-generator-cli@2.38.0':
+  '@openapitools/openapi-generator-cli@2.39.0':
     dependencies:
       '@inquirer/select': 1.3.3
-      '@nestjs/axios': 4.0.1(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.18.0)(rxjs@7.8.2)
-      '@nestjs/common': 11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2)
-      '@nestjs/core': 11.1.26(@nestjs/common@11.1.26(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/axios': 4.0.1(@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2))(axios@1.18.0)(rxjs@7.8.2)
+      '@nestjs/common': 11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2)
+      '@nestjs/core': 11.1.27(@nestjs/common@11.1.27(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nuxtjs/opencollective': 0.3.2
       axios: 1.18.0
       chalk: 4.1.2
@@ -6993,6 +7266,13 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  '@react-email/render@2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.8.4
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@react-email/row@0.0.13(react@19.2.4)':
     dependencies:
       react: 19.2.4
@@ -7047,6 +7327,10 @@ snapshots:
       '@peculiar/asn1-schema': 2.8.0
       '@peculiar/asn1-x509': 2.8.0
       '@peculiar/x509': 1.14.3
+
+  '@socket.io/component-emitter@3.1.2': {}
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -7175,7 +7459,7 @@ snapshots:
       '@triplit/logger': 0.0.3(typescript@5.9.3)
       core-js: 3.49.0
       elen: 1.0.10
-      nanoid: 5.1.14
+      nanoid: 5.1.15
       sorted-btree: 1.8.1
       web-worker: 1.5.0
     transitivePeerDependencies:
@@ -7200,6 +7484,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 25.9.4
 
   '@types/d3-array@3.2.2': {}
 
@@ -7264,6 +7552,10 @@ snapshots:
       csstype: 3.2.3
 
   '@types/wrap-ansi@3.0.0': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.4
 
   '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
@@ -7443,6 +7735,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/emscripten'
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -7457,12 +7754,23 @@ snapshots:
 
   agent-base@9.0.0: {}
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-escapes@4.3.2:
     dependencies:
@@ -7569,6 +7877,11 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  atomically@2.1.1:
+    dependencies:
+      stubborn-fs: 2.0.0
+      when-exit: 2.1.5
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -7596,6 +7909,8 @@ snapshots:
       zxing-wasm: 3.1.0(@types/emscripten@1.41.5)
     transitivePeerDependencies:
       - '@types/emscripten'
+
+  base64id@2.0.0: {}
 
   baseline-browser-mapping@2.10.38: {}
 
@@ -7709,6 +8024,12 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  citty@0.2.2: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -7754,6 +8075,8 @@ snapshots:
 
   comlink@4.4.2: {}
 
+  commander@13.1.0: {}
+
   commander@8.3.0: {}
 
   compare-versions@6.1.1: {}
@@ -7769,6 +8092,18 @@ snapshots:
       tree-kill: 1.2.2
       yargs: 18.0.0
 
+  conf@15.1.0:
+    dependencies:
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      atomically: 2.1.1
+      debounce-fn: 6.0.0
+      dot-prop: 10.1.0
+      env-paths: 3.0.0
+      json-schema-typed: 8.0.2
+      semver: 7.8.5
+      uint8array-extras: 1.5.0
+
   consola@2.15.3: {}
 
   console.table@0.10.0:
@@ -7777,17 +8112,29 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@0.7.2: {}
+
   copy-anything@4.0.5:
     dependencies:
       is-what: 5.5.0
 
   core-js@3.49.0: {}
 
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
 
   csstype@3.2.3: {}
 
@@ -7850,6 +8197,12 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  debounce-fn@6.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  debounce@2.2.0: {}
 
   debug@3.2.7:
     dependencies:
@@ -7924,6 +8277,10 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  dot-prop@10.1.0:
+    dependencies:
+      type-fest: 5.7.0
+
   dotenv@17.4.2: {}
 
   drizzle-kit@0.31.10:
@@ -7959,12 +8316,33 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  engine.io-parser@5.2.3: {}
+
+  engine.io@6.6.9:
+    dependencies:
+      '@types/cors': 2.8.19
+      '@types/node': 25.9.4
+      '@types/ws': 8.18.1
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.7.2
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   enhanced-resolve@5.21.6:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
   entities@4.5.0: {}
+
+  env-paths@3.0.0: {}
 
   es-abstract-get@1.0.0:
     dependencies:
@@ -8412,6 +8790,10 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-sha256@1.3.0: {}
+
+  fast-uri@3.1.2: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -8563,6 +8945,8 @@ snapshots:
       minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  globals@11.12.0: {}
 
   globals@14.0.0: {}
 
@@ -8784,6 +9168,8 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.22
 
+  is-unicode-supported@2.1.0: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -8812,6 +9198,8 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  jiti@2.4.2: {}
+
   jiti@2.7.0: {}
 
   jose@6.2.3: {}
@@ -8827,6 +9215,10 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -8852,6 +9244,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kleur@3.0.3: {}
 
   kleur@4.1.5: {}
 
@@ -8929,6 +9323,11 @@ snapshots:
 
   lodash@4.18.1: {}
 
+  log-symbols@7.0.1:
+    dependencies:
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -8953,6 +9352,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdn-data@2.27.1: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -8962,9 +9363,17 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  mimic-function@5.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -9000,15 +9409,17 @@ snapshots:
 
   mute-stream@1.0.0: {}
 
-  nanoid@3.3.13: {}
+  nanoid@3.3.14: {}
 
-  nanoid@5.1.14: {}
+  nanoid@5.1.15: {}
 
   nanostores@1.3.0: {}
 
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@0.6.3: {}
 
   netmask@2.1.1: {}
 
@@ -9048,6 +9459,14 @@ snapshots:
       whatwg-url: 5.0.0
 
   node-releases@2.0.48: {}
+
+  normalize-path@3.0.0: {}
+
+  nypm@0.6.6:
+    dependencies:
+      citty: 0.2.2
+      pathe: 2.0.3
+      tinyexec: 1.2.4
 
   object-assign@4.1.1: {}
 
@@ -9156,6 +9575,8 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
+  pathe@2.0.3: {}
+
   peberminta@0.9.0: {}
 
   pg-cloudflare@1.4.0:
@@ -9199,6 +9620,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  picospinner@3.0.0: {}
+
   playwright-core@1.61.0: {}
 
   playwright@1.61.0:
@@ -9209,15 +9632,17 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.4: {}
+
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.13
+      nanoid: 3.3.14
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.13
+      nanoid: 3.3.14
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -9238,6 +9663,11 @@ snapshots:
   prettier@3.8.4: {}
 
   prismjs@1.30.0: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
 
   prop-types@15.8.1:
     dependencies:
@@ -9351,6 +9781,37 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-email@6.6.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@babel/traverse': 7.27.0
+      '@react-email/render': 2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      chokidar: 4.0.3
+      commander: 13.1.0
+      conf: 15.1.0
+      css-tree: 3.2.1
+      debounce: 2.2.0
+      esbuild: 0.28.1
+      glob: 13.0.6
+      jiti: 2.4.2
+      log-symbols: 7.0.1
+      marked: 15.0.12
+      mime-types: 3.0.2
+      normalize-path: 3.0.0
+      nypm: 0.6.6
+      picospinner: 3.0.0
+      prismjs: 1.30.0
+      prompts: 2.4.2
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      socket.io: 4.8.3
+      tailwindcss: 4.3.1
+      tsconfig-paths: 4.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   react-google-recaptcha@3.1.0(react@19.2.4):
     dependencies:
       prop-types: 15.8.1
@@ -9446,6 +9907,8 @@ snapshots:
 
   react@19.2.4: {}
 
+  readdirp@4.1.2: {}
+
   recharts-scale@0.4.5:
     dependencies:
       decimal.js-light: 2.5.1
@@ -9484,6 +9947,15 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  require-from-string@2.0.2: {}
+
+  resend@6.14.0(@react-email/render@2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+    dependencies:
+      postal-mime: 2.7.4
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      '@react-email/render': 2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   resolve-from@4.0.0: {}
 
@@ -9641,6 +10113,36 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
+  socket.io-adapter@2.5.8:
+    dependencies:
+      debug: 4.4.3
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.6:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  socket.io@4.8.3:
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io: 6.6.9
+      socket.io-adapter: 2.5.8
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   socks-proxy-agent@10.1.0:
     dependencies:
       agent-base: 9.0.0
@@ -9673,6 +10175,11 @@ snapshots:
   split2@4.2.0: {}
 
   stable-hash@0.0.5: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -9758,6 +10265,12 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
+  stubborn-fs@2.0.0:
+    dependencies:
+      stubborn-utils: 1.0.2
+
+  stubborn-utils@1.0.2: {}
+
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
@@ -9787,6 +10300,8 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -9814,6 +10329,12 @@ snapshots:
     dependencies:
       '@types/json5': 0.0.29
       json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
 
@@ -9968,6 +10489,8 @@ snapshots:
 
   uuid@11.1.1: {}
 
+  vary@1.1.2: {}
+
   vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@radix-ui/react-dialog': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -10018,6 +10541,8 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  when-exit@2.1.5: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -10078,6 +10603,8 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
+  ws@8.21.0: {}
+
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
@@ -10096,6 +10623,8 @@ snapshots:
       yargs-parser: 22.0.0
 
   yocto-queue@0.1.0: {}
+
+  yoctocolors@2.1.2: {}
 
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:

--- a/frontend/src/app/api/account/register/route.ts
+++ b/frontend/src/app/api/account/register/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { auth } from "@/lib/auth";
+import { requireEnv } from "@/lib/env";
+import { passwordSchema } from "@/lib/api/schemas/auth-user";
+
+const registerSchema = z.object({
+  email: z.email(),
+  password: passwordSchema,
+});
+
+// Email+password registration that also works when the email already has a social account.
+// Branches server-side and always responds the same way (no account-existence enumeration):
+// - new email -> normal sign-up, which sends the verification email
+// - existing account -> a "set your password" link via the reset flow, which links a credential
+//   account for password-less (Google/Facebook) users, giving them email login too.
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const parsed = registerSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+  }
+
+  const email = parsed.data.email.toLowerCase();
+  const ctx = await auth.$context;
+  const existing = await ctx.internalAdapter.findUserByEmail(email);
+
+  if (existing) {
+    await auth.api.requestPasswordReset({
+      body: {
+        email,
+        // email is carried back so the reset page can sign the user in automatically.
+        redirectTo: `${requireEnv("BETTER_AUTH_URL")}/reset-password?email=${encodeURIComponent(email)}`,
+      },
+    });
+  } else {
+    await auth.api.signUpEmail({
+      body: {
+        email,
+        password: parsed.data.password,
+        name: email.split("@")[0],
+      },
+    });
+  }
+
+  return NextResponse.json({ status: true });
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import { AppSidebar } from "@/components/custom/app-sidebar";
 import Header from "@/components/custom/header/header";
 import Footer from "@/components/custom/footer";
+import OAuthErrorToast from "@/components/custom/oauth-error-toast";
 import { Providers } from "@/app/providers/providers";
 import { ReactNode, Suspense } from "react";
 import { sairaStencil } from "@/app/fonts";
@@ -65,6 +66,10 @@ export default function RootLayout({
         className={`${sairaStencil.variable} antialiased bg-zinc-50 relative`}
       >
         <Providers>
+          <Suspense fallback={null}>
+            <OAuthErrorToast />
+          </Suspense>
+
           <div className="min-h-screen flex flex-col w-full">
             {/* pattern background */}
             <div className="absolute inset-0 z-[-15] bg-[url('/+_pattern.png')] bg-repeat opacity-100" />

--- a/frontend/src/app/reset-password/page.tsx
+++ b/frontend/src/app/reset-password/page.tsx
@@ -1,0 +1,20 @@
+import { Metadata } from "next";
+
+import ResetPasswordModal from "@/app/reset-password/reset-password-modal";
+
+export const metadata: Metadata = {
+  title: "Nova lozinka",
+  description: "Postavi novu lozinku za svoj Disscount račun.",
+};
+
+interface IPageProps {
+  searchParams?: Promise<{ token?: string; email?: string }>;
+}
+
+export default async function ResetPasswordPage({ searchParams }: IPageProps) {
+  const params = await searchParams;
+  const token = params?.token ?? "";
+  const email = params?.email;
+
+  return <ResetPasswordModal token={token} email={email} />;
+}

--- a/frontend/src/app/reset-password/reset-password-modal.tsx
+++ b/frontend/src/app/reset-password/reset-password-modal.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { PasswordInput } from "@/components/ui/password-input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { passwordSchema } from "@/lib/api/schemas/auth-user";
+import { authClient } from "@/lib/auth-client";
+import { useUser } from "@/context/user-context";
+
+const resetPasswordSchema = z
+  .object({
+    password: passwordSchema,
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Lozinke se ne podudaraju",
+    path: ["confirmPassword"],
+  });
+
+type ResetPasswordFormType = z.infer<typeof resetPasswordSchema>;
+
+interface IResetPasswordModalProps {
+  token: string;
+  email?: string;
+}
+
+// Opened from the password-reset / set-password email link
+// (/reset-password?token=...&email=...). Rendered as a modal over the app, matching the auth
+// dialogs. On success the user is signed in automatically with the new password.
+export default function ResetPasswordModal({
+  token,
+  email,
+}: IResetPasswordModalProps) {
+  const router = useRouter();
+  const { handleUserLogin } = useUser();
+
+  const form = useForm<ResetPasswordFormType>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: { password: "", confirmPassword: "" },
+  });
+
+  function goHome() {
+    router.push("/");
+  }
+
+  async function onSubmit(data: ResetPasswordFormType) {
+    const { error } = await authClient.resetPassword({
+      newPassword: data.password,
+      token,
+    });
+
+    if (error) {
+      toast.error("Poveznica je nevažeća ili je istekla. Zatraži novu.");
+      return;
+    }
+
+    // Sign the user in automatically with the new password when we know the email.
+    if (email) {
+      const { error: signInError } = await authClient.signIn.email({
+        email,
+        password: data.password,
+      });
+
+      if (!signInError) {
+        await handleUserLogin();
+        toast.success("Lozinka je postavljena. Prijavljen si!");
+        router.push("/");
+        return;
+      }
+    }
+
+    toast.success("Lozinka je postavljena. Sada se možeš prijaviti.");
+    router.push("/");
+  }
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) goHome();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="text-xl">Nova lozinka</DialogTitle>
+          <DialogDescription>
+            Postavi novu lozinku za svoj Disscount račun.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!token ? (
+          <p className="text-sm text-red-700">
+            Nedostaje token. Zatraži novu poveznicu putem „Zaboravljena
+            lozinka?“ na prijavi.
+          </p>
+        ) : (
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="grid gap-4">
+              <FormField
+                control={form.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nova lozinka</FormLabel>
+                    <FormControl>
+                      <PasswordInput
+                        {...field}
+                        placeholder="••••••••"
+                        autoComplete="new-password"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="confirmPassword"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Potvrdi novu lozinku</FormLabel>
+                    <FormControl>
+                      <PasswordInput
+                        {...field}
+                        placeholder="••••••••"
+                        autoComplete="new-password"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <Button
+                type="submit"
+                size="lg"
+                className="w-full"
+                disabled={form.formState.isSubmitting}
+              >
+                {form.formState.isSubmitting ? (
+                  <Loader2 size={16} className="animate-spin" />
+                ) : (
+                  "Postavi lozinku"
+                )}
+              </Button>
+            </form>
+          </Form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/custom/header/forms/auth-modal.tsx
+++ b/frontend/src/components/custom/header/forms/auth-modal.tsx
@@ -17,6 +17,7 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { LoginForm } from "@/components/custom/header/forms/login-form";
 import { SignUpForm } from "@/components/custom/header/forms/signup-form";
+import { ForgotPasswordForm } from "@/components/custom/header/forms/forgot-password-form";
 import { GoogleIcon } from "@/components/icons/google-icon";
 import { FacebookIcon } from "@/components/icons/facebook-icon";
 import {
@@ -30,11 +31,10 @@ interface IAuthModalProps {
   onOpenChange: (open: boolean) => void;
 }
 
-type AuthMode = "login" | "signup";
+type AuthMode = "login" | "signup" | "forgot";
 
 export function AuthModal({ isOpen, onOpenChange }: IAuthModalProps) {
   const [authMode, setAuthMode] = useState<AuthMode>("login");
-  const [showOnboarding, setShowOnboarding] = useState(false);
   const [lastLoginMethod, setLastLoginMethodState] = useState<LoginMethod | null>(
     null,
   );
@@ -46,37 +46,12 @@ export function AuthModal({ isOpen, onOpenChange }: IAuthModalProps) {
     setLastLoginMethodState(getLastLoginMethod());
   }, [isOpen]);
 
-  // Surface OAuth failures: better-auth redirects to "/" with ?error=<code>.
-  // The only social error we can produce is a Facebook login without email.
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-
-    const params = new URLSearchParams(window.location.search);
-    const error = params.get("error");
-    if (!error) return;
-
-    toast.error(
-      error === "email_not_found"
-        ? "Tvoj Facebook račun nije podijelio email adresu. Prijavi se emailom ili Facebook računom koji ima email."
-        : "Greška pri prijavi. Pokušaj ponovo.",
-    );
-
-    params.delete("error");
-    const query = params.toString();
-    window.history.replaceState(
-      {},
-      "",
-      window.location.pathname + (query ? `?${query}` : ""),
-    );
-  }, []);
-
   const handleLoginSuccess = () => {
     onOpenChange(false);
   };
 
-  const handleSignUpSuccess = () => {
-    onOpenChange(false);
-    setShowOnboarding(true);
+  const handleForgotPassword = () => {
+    setAuthMode("forgot");
   };
 
   async function handleSocialSignIn(provider: "google" | "facebook") {
@@ -111,33 +86,43 @@ export function AuthModal({ isOpen, onOpenChange }: IAuthModalProps) {
       <DialogContent>
         <DialogHeader>
           <DialogTitle className="text-xl mb-2">
-            {authMode === "login" ? "Prijava" : "Registracija"}
+            {authMode === "login"
+              ? "Prijava"
+              : authMode === "signup"
+                ? "Registracija"
+                : "Zaboravljena lozinka"}
           </DialogTitle>
         </DialogHeader>
 
         <div className="grid gap-8">
-          {authMode === "login" ? (
+          {authMode === "login" && (
             <LoginForm
               onSuccess={handleLoginSuccess}
+              onForgotPassword={handleForgotPassword}
               isLastUsed={lastLoginMethod === "email"}
-              externalDisabled={socialPending !== null}
-            />
-          ) : (
-            <SignUpForm
-              onSuccess={handleSignUpSuccess}
               externalDisabled={socialPending !== null}
             />
           )}
 
-          <div className="relative">
-            <Separator />
+          {authMode === "signup" && (
+            <SignUpForm externalDisabled={socialPending !== null} />
+          )}
 
-            <div className="absolute inset-0 flex items-center justify-center">
-              <span className="bg-background px-4 text-muted-foreground">
-                ili
-              </span>
-            </div>
-          </div>
+          {authMode === "forgot" && (
+            <ForgotPasswordForm onBackToLogin={switchToLogin} />
+          )}
+
+          {authMode !== "forgot" && (
+            <>
+              <div className="relative">
+                <Separator />
+
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <span className="bg-background px-4 text-muted-foreground">
+                    ili
+                  </span>
+                </div>
+              </div>
 
           <Button
             variant="outline"
@@ -193,15 +178,17 @@ export function AuthModal({ isOpen, onOpenChange }: IAuthModalProps) {
               target="_blank"
               rel="noopener noreferrer"
               className="underline hover:text-primary"
-            >
-              Pravila privatnosti
-            </Link>
-            .
-          </p>
+                >
+                  Pravila privatnosti
+                </Link>
+                .
+              </p>
+            </>
+          )}
         </div>
 
         <DialogFooter className="text-xs text-gray-500 text-center my-2 block">
-          {authMode === "login" ? (
+          {authMode === "login" && (
             <>
               Još nemaš račun?{" "}
               <button
@@ -212,7 +199,9 @@ export function AuthModal({ isOpen, onOpenChange }: IAuthModalProps) {
                 Registriraj se
               </button>
             </>
-          ) : (
+          )}
+
+          {authMode === "signup" && (
             <>
               Već imaš račun?{" "}
               <button

--- a/frontend/src/components/custom/header/forms/forgot-password-form.tsx
+++ b/frontend/src/components/custom/header/forms/forgot-password-form.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { authClient } from "@/lib/auth-client";
+import { cn } from "@/lib/utils";
+import InboxNotice from "@/components/custom/header/forms/inbox-notice";
+
+const forgotPasswordSchema = z.object({
+  email: z.email("Unesi važeći email"),
+});
+
+type ForgotPasswordFormType = z.infer<typeof forgotPasswordSchema>;
+
+interface IForgotPasswordFormProps {
+  onBackToLogin: () => void;
+}
+
+export function ForgotPasswordForm({ onBackToLogin }: IForgotPasswordFormProps) {
+  const [submittedEmail, setSubmittedEmail] = useState<string | null>(null);
+
+  const form = useForm<ForgotPasswordFormType>({
+    resolver: zodResolver(forgotPasswordSchema),
+    defaultValues: { email: "" },
+  });
+
+  async function onSubmit(data: ForgotPasswordFormType) {
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? window.location.origin;
+
+    const { error } = await authClient.requestPasswordReset({
+      email: data.email,
+      // email is carried back so the reset page can sign the user in automatically.
+      redirectTo: `${appUrl}/reset-password?email=${encodeURIComponent(data.email)}`,
+    });
+
+    if (error) {
+      toast.error("Greška pri slanju poveznice. Pokušaj ponovo.");
+      return;
+    }
+
+    setSubmittedEmail(data.email);
+  }
+
+  if (submittedEmail) {
+    return (
+      <InboxNotice
+        title="Provjeri svoj inbox"
+        description="Ako račun s tom adresom postoji, poslali smo poveznicu za ponovno postavljanje lozinke na:"
+        email={submittedEmail}
+      />
+    );
+  }
+
+  return (
+    <form onSubmit={form.handleSubmit(onSubmit)} className="grid gap-4">
+      <p className="text-sm text-muted-foreground">
+        Unesi svoju email adresu i poslat ćemo ti poveznicu za postavljanje nove
+        lozinke.
+      </p>
+
+      <div className="grid gap-2">
+        <Label htmlFor="forgot-email">Email</Label>
+        <Input
+          id="forgot-email"
+          type="email"
+          placeholder="korisnik@example.com"
+          autoComplete="email"
+          {...form.register("email")}
+          className={cn(form.formState.errors.email && "border-red-700")}
+        />
+        {form.formState.errors.email && (
+          <p className="text-sm text-red-700">
+            {form.formState.errors.email.message}
+          </p>
+        )}
+      </div>
+
+      <Button
+        type="submit"
+        size="lg"
+        className="w-full"
+        disabled={form.formState.isSubmitting}
+      >
+        {form.formState.isSubmitting ? (
+          <Loader2 size={16} className="animate-spin" />
+        ) : (
+          "Pošalji poveznicu"
+        )}
+      </Button>
+
+      <button
+        type="button"
+        onClick={onBackToLogin}
+        className="cursor-pointer text-sm text-primary underline hover:text-primary/80"
+      >
+        Natrag na prijavu
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/custom/header/forms/inbox-notice.tsx
+++ b/frontend/src/components/custom/header/forms/inbox-notice.tsx
@@ -1,0 +1,41 @@
+import { MailCheck } from "lucide-react";
+
+interface IInboxNoticeProps {
+  title: string;
+  description: string;
+  email?: string;
+  hint?: string;
+}
+
+// Shown after an action that sends an email (signup verification, password reset request)
+// so the user knows to go check their inbox.
+export default function InboxNotice({
+  title,
+  description,
+  email,
+  hint,
+}: IInboxNoticeProps) {
+  return (
+    <div className="flex flex-col items-center gap-3 py-4 text-center">
+      <div className="flex size-12 items-center justify-center rounded-full bg-green-100 text-primary">
+        <MailCheck className="size-6" />
+      </div>
+
+      <h3 className="text-lg font-semibold">{title}</h3>
+
+      <p className="text-sm text-muted-foreground">{description}</p>
+
+      {email && <p className="text-sm font-medium">{email}</p>}
+
+      <p className="text-xs text-muted-foreground">
+        Ne zaboravi provjeriti i spam / neželjenu poštu.
+      </p>
+
+      {hint && (
+        <p className="mt-1 rounded-md border border-dashed bg-muted/40 p-2.5 text-xs text-muted-foreground">
+          {hint}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/custom/header/forms/linked-accounts.tsx
+++ b/frontend/src/components/custom/header/forms/linked-accounts.tsx
@@ -45,9 +45,12 @@ export default function LinkedAccounts({
     setPending(provider);
     try {
       // Redirects to the provider and back; the account is linked on return.
+      // errorCallbackURL brings failures (e.g. email_doesn't_match) back into the app,
+      // where useOAuthErrorToast shows a localized message instead of Better Auth's error page.
       await authClient.linkSocial({
         provider,
         callbackURL: window.location.pathname,
+        errorCallbackURL: window.location.pathname,
       });
     } catch {
       toast.error("Greška pri povezivanju računa.");

--- a/frontend/src/components/custom/header/forms/login-form.tsx
+++ b/frontend/src/components/custom/header/forms/login-form.tsx
@@ -25,11 +25,17 @@ import { PasswordInput } from "@/components/ui/password-input";
 
 interface ILoginFormProps {
   onSuccess?: () => void;
+  onForgotPassword: () => void;
   isLastUsed?: boolean;
   externalDisabled?: boolean;
 }
 
-export function LoginForm({ onSuccess, isLastUsed, externalDisabled }: ILoginFormProps) {
+export function LoginForm({
+  onSuccess,
+  onForgotPassword,
+  isLastUsed,
+  externalDisabled,
+}: ILoginFormProps) {
   const { handleUserLogin } = useUser();
 
   const form = useForm<LoginRequest>({
@@ -51,10 +57,16 @@ export function LoginForm({ onSuccess, isLastUsed, externalDisabled }: ILoginFor
 
       if (result.error) {
         const status = result.error.status ?? 0;
-        const message =
-          status === 401 || status === 400
-            ? "Neispravni email ili lozinka"
-            : result.error.message || "Provjeri unesene podatke.";
+        let message: string;
+        if (status === 403) {
+          // Email not verified — better-auth re-sends the verification link on each attempt.
+          message =
+            "Tvoj email još nije potvrđen. Poslali smo ti novu poveznicu — provjeri inbox (i spam).";
+        } else if (status === 401 || status === 400) {
+          message = "Neispravni email ili lozinka";
+        } else {
+          message = result.error.message || "Provjeri unesene podatke.";
+        }
         form.setError("root", { type: "server", message });
         return;
       }
@@ -119,6 +131,14 @@ export function LoginForm({ onSuccess, isLastUsed, externalDisabled }: ILoginFor
             </FormItem>
           )}
         />
+
+        <button
+          type="button"
+          onClick={onForgotPassword}
+          className="-mt-2 justify-self-end cursor-pointer text-sm text-primary underline hover:text-primary/80"
+        >
+          Zaboravljena lozinka?
+        </button>
 
         <Button type="submit" size="lg" className="w-full" disabled={form.formState.isSubmitting || externalDisabled}>
           {form.formState.isSubmitting ? (

--- a/frontend/src/components/custom/header/forms/profile-modal.tsx
+++ b/frontend/src/components/custom/header/forms/profile-modal.tsx
@@ -16,6 +16,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
@@ -264,6 +265,40 @@ export default function ProfileModal({
                 </FormItem>
               )}
             />
+
+            {/* Coming-soon email features (disabled placeholders) */}
+            {[
+              {
+                label: "Novosti i ažuriranja",
+                description: "Povremene novosti o Disscountu na tvoj email.",
+              },
+              {
+                label: "Sniženja s liste praćenja",
+                description:
+                  "Email kad proizvod s tvoje liste praćenja padne na akciju.",
+              },
+              {
+                label: "Kontakt za povratne informacije",
+                description:
+                  "Dopusti da ti se javimo za povratne informacije o aplikaciji.",
+              },
+            ].map((item) => (
+              <div
+                key={item.label}
+                className="flex flex-row items-center justify-between rounded-lg border p-4 opacity-60"
+              >
+                <div className="space-y-0.5">
+                  <div className="flex items-center gap-2">
+                    <p className="text-sm font-medium">{item.label}</p>
+                    <Badge className="text-[10px]">USKORO</Badge>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    {item.description}
+                  </p>
+                </div>
+                <Switch checked={false} disabled />
+              </div>
+            ))}
 
             <div className="flex justify-between">
               <Button

--- a/frontend/src/components/custom/header/forms/signup-form.tsx
+++ b/frontend/src/components/custom/header/forms/signup-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2 } from "lucide-react";
@@ -19,17 +20,16 @@ import {
 import { PasswordInput } from "@/components/ui/password-input";
 import { registerRequestSchema, RegisterRequest } from "@/lib/api/schemas/auth-user";
 import { cn } from "@/lib/utils";
-import { signUp } from "@/lib/auth-client";
-import { useUser } from "@/context/user-context";
-import { setLastLoginMethod } from "@/utils/browser/local-storage";
+import InboxNotice from "@/components/custom/header/forms/inbox-notice";
 
 interface ISignUpFormProps {
-  onSuccess?: () => void;
   externalDisabled?: boolean;
 }
 
-export function SignUpForm({ onSuccess, externalDisabled }: ISignUpFormProps) {
-  const { handleUserLogin } = useUser();
+export function SignUpForm({ externalDisabled }: ISignUpFormProps) {
+  // Set once signup succeeds — email verification is required, so we don't log in;
+  // we show a "check your inbox" notice instead.
+  const [submittedEmail, setSubmittedEmail] = useState<string | null>(null);
 
   const form = useForm<RegisterRequest>({
     resolver: zodResolver(registerRequestSchema),
@@ -44,29 +44,37 @@ export function SignUpForm({ onSuccess, externalDisabled }: ISignUpFormProps) {
     form.clearErrors("root");
 
     try {
-      const result = await signUp.email({
-        name: data.email.split("@")[0],
-        email: data.email,
-        password: data.password,
+      // The endpoint always responds the same way (no account-existence enumeration):
+      // a new email gets a verification link, an existing account a "set password" link.
+      const response = await fetch("/api/account/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: data.email, password: data.password }),
       });
 
-      if (result.error) {
-        const message =
-          result.error.status === 422
-            ? "Korisnik s tim emailom već postoji"
-            : result.error.message || "Provjeri unesene podatke.";
-        form.setError("root", { type: "server", message });
+      if (!response.ok) {
+        form.setError("root", {
+          type: "server",
+          message: "Provjeri unesene podatke.",
+        });
         return;
       }
 
-      await handleUserLogin();
-      toast.success("Uspješno ste se registrirali!");
+      setSubmittedEmail(data.email);
       form.reset();
-      setLastLoginMethod("email");
-      onSuccess?.();
     } catch {
       toast.error("Greška pri registraciji. Pokušaj ponovo.");
     }
+  }
+
+  if (submittedEmail) {
+    return (
+      <InboxNotice
+        title="Provjeri svoj inbox"
+        description="Poslali smo ti email s poveznicom za dovršetak prijave na:"
+        email={submittedEmail}
+      />
+    );
   }
 
   return (

--- a/frontend/src/components/custom/oauth-error-toast.tsx
+++ b/frontend/src/components/custom/oauth-error-toast.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+import { toast } from "sonner";
+
+// Maps Better Auth OAuth error codes (appended as ?error= on a failed sign-in or
+// account-linking redirect) to localized, user-friendly messages.
+const ERROR_MESSAGES: Record<string, string> = {
+  email_not_found:
+    "Tvoj Facebook račun nije podijelio email adresu. Prijavi se emailom ili Facebook računom koji ima email.",
+  "email_doesn't_match":
+    "Taj račun koristi drugu email adresu. Možeš povezati samo račune s istom email adresom.",
+};
+
+const DEFAULT_MESSAGE = "Došlo je do greške. Pokušaj ponovo.";
+
+// Surfaces failed OAuth flows (social sign-in or account linking) as a toast.
+// Reads ?error= via useSearchParams (Next's router snapshot) instead of window.location:
+// the redirect's URL gets rewritten during session load, which previously lost the toast.
+// The router snapshot is unaffected by that raw rewrite, so the message reliably shows.
+export default function OAuthErrorToast() {
+  const searchParams = useSearchParams();
+  const error = searchParams.get("error");
+  const shown = useRef(false);
+
+  useEffect(() => {
+    if (!error || shown.current) return;
+
+    shown.current = true;
+    toast.error(ERROR_MESSAGES[error] ?? DEFAULT_MESSAGE, { duration: 6000 });
+
+    // Strip the param from the address bar so a refresh doesn't re-show it.
+    const params = new URLSearchParams(window.location.search);
+    if (params.has("error")) {
+      params.delete("error");
+      params.delete("error_description");
+      const query = params.toString();
+      window.history.replaceState(
+        {},
+        "",
+        window.location.pathname + (query ? `?${query}` : ""),
+      );
+    }
+  }, [error]);
+
+  return null;
+}

--- a/frontend/src/emails/change-email-verification.tsx
+++ b/frontend/src/emails/change-email-verification.tsx
@@ -1,0 +1,33 @@
+import ActionEmail from "./components/action-email";
+
+interface IChangeEmailVerificationProps {
+  confirmUrl: string;
+  newEmail: string;
+}
+
+export default function ChangeEmailVerification({
+  confirmUrl,
+  newEmail,
+}: IChangeEmailVerificationProps) {
+  return (
+    <ActionEmail
+      preview="Potvrdi promjenu email adrese"
+      heading="Potvrdi promjenu email adrese"
+      intro={
+        <>
+          Zatražena je promjena email adrese tvog računa na{" "}
+          <span className="font-semibold text-gray-800">{newEmail}</span>.
+          Klikni na gumb ispod kako bi potvrdio promjenu.
+        </>
+      }
+      buttonLabel="Potvrdi promjenu"
+      buttonUrl={confirmUrl}
+      footnote="Ako nisi ti zatražio ovu promjenu, odmah promijeni lozinku i javi nam se."
+    />
+  );
+}
+
+ChangeEmailVerification.PreviewProps = {
+  confirmUrl: "https://disscount.me/api/auth/verify-email?token=preview",
+  newEmail: "nova@email.com",
+} satisfies IChangeEmailVerificationProps;

--- a/frontend/src/emails/components/action-email.tsx
+++ b/frontend/src/emails/components/action-email.tsx
@@ -1,0 +1,45 @@
+import { ReactNode } from "react";
+import { Button, Section, Text } from "react-email";
+
+import EmailLayout from "./email-layout";
+
+interface IActionEmailProps {
+  preview: string;
+  heading: string;
+  intro: ReactNode;
+  buttonLabel: string;
+  buttonUrl: string;
+  footnote: string;
+}
+
+// Shared layout for the single-call-to-action transactional emails
+// (verification, password reset, change-email confirmation).
+export default function ActionEmail({
+  preview,
+  heading,
+  intro,
+  buttonLabel,
+  buttonUrl,
+  footnote,
+}: IActionEmailProps) {
+  return (
+    <EmailLayout preview={preview}>
+      <Text className="m-0 mb-2 text-xl font-bold text-gray-800">{heading}</Text>
+
+      <Text className="m-0 mb-6 text-sm leading-relaxed text-gray-600">
+        {intro}
+      </Text>
+
+      <Section className="mb-6">
+        <Button
+          href={buttonUrl}
+          className="box-border rounded-md bg-brand px-6 py-3 text-center text-sm font-semibold text-white no-underline"
+        >
+          {buttonLabel}
+        </Button>
+      </Section>
+
+      <Text className="m-0 text-xs text-gray-500">{footnote}</Text>
+    </EmailLayout>
+  );
+}

--- a/frontend/src/emails/components/email-layout.tsx
+++ b/frontend/src/emails/components/email-layout.tsx
@@ -1,0 +1,66 @@
+import { ReactNode } from "react";
+import {
+  Body,
+  Container,
+  Head,
+  Hr,
+  Html,
+  Link,
+  Preview,
+  Tailwind,
+  Text,
+  pixelBasedPreset,
+} from "react-email";
+
+// Brand green, matching the app's --primary (oklch ~141 hue) as a hex email clients understand.
+const BRAND = "#16a34a";
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://disscount.me";
+
+interface IEmailLayoutProps {
+  preview: string;
+  children: ReactNode;
+}
+
+// Shared shell for every transactional email: brand wordmark, content, and a footer that
+// always links back to the app where the user can manage their email preferences.
+export default function EmailLayout({ preview, children }: IEmailLayoutProps) {
+  return (
+    <Html lang="hr">
+      <Tailwind
+        config={{
+          presets: [pixelBasedPreset],
+          theme: { extend: { colors: { brand: BRAND } } },
+        }}
+      >
+        <Head />
+        <Body className="bg-gray-100 font-sans">
+          <Preview>{preview}</Preview>
+
+          <Container className="mx-auto my-8 max-w-xl rounded-lg border border-solid border-gray-200 bg-white p-8">
+            <Text className="m-0 mb-6 text-2xl font-bold text-brand">
+              disscount
+            </Text>
+
+            {children}
+
+            <Hr className="my-6 border-solid border-gray-200" />
+
+            <Text className="m-0 text-xs text-gray-500">
+              Ovaj email primaš jer imaš račun na Disscountu. Email postavke
+              možeš promijeniti tako da se{" "}
+              <Link href={APP_URL} className="text-brand underline">
+                prijaviš na Disscount
+              </Link>
+              .
+            </Text>
+
+            <Text className="m-0 mt-2 text-xs text-gray-400">
+              © {new Date().getFullYear()} Disscount
+            </Text>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+}

--- a/frontend/src/emails/password-reset-email.tsx
+++ b/frontend/src/emails/password-reset-email.tsx
@@ -1,0 +1,24 @@
+import ActionEmail from "./components/action-email";
+
+interface IPasswordResetEmailProps {
+  resetUrl: string;
+}
+
+export default function PasswordResetEmail({
+  resetUrl,
+}: IPasswordResetEmailProps) {
+  return (
+    <ActionEmail
+      preview="Ponovno postavi svoju lozinku za Disscount"
+      heading="Ponovno postavljanje lozinke"
+      intro="Zatražio si ponovno postavljanje lozinke. Klikni na gumb ispod kako bi postavio novu lozinku. Poveznica vrijedi ograničeno vrijeme."
+      buttonLabel="Postavi novu lozinku"
+      buttonUrl={resetUrl}
+      footnote="Ako nisi ti zatražio ovu promjenu, zanemari ovaj email — tvoja lozinka ostaje nepromijenjena."
+    />
+  );
+}
+
+PasswordResetEmail.PreviewProps = {
+  resetUrl: "https://disscount.me/reset-password?token=preview",
+} satisfies IPasswordResetEmailProps;

--- a/frontend/src/emails/verification-email.tsx
+++ b/frontend/src/emails/verification-email.tsx
@@ -1,0 +1,24 @@
+import ActionEmail from "./components/action-email";
+
+interface IVerificationEmailProps {
+  verificationUrl: string;
+}
+
+export default function VerificationEmail({
+  verificationUrl,
+}: IVerificationEmailProps) {
+  return (
+    <ActionEmail
+      preview="Potvrdi svoju email adresu za Disscount"
+      heading="Potvrdi svoju email adresu"
+      intro="Hvala na registraciji! Klikni na gumb ispod kako bi potvrdio svoju email adresu i aktivirao svoj račun."
+      buttonLabel="Potvrdi email"
+      buttonUrl={verificationUrl}
+      footnote="Ako nisi ti napravio ovaj račun, slobodno zanemari ovaj email."
+    />
+  );
+}
+
+VerificationEmail.PreviewProps = {
+  verificationUrl: "https://disscount.me/api/auth/verify-email?token=preview",
+} satisfies IVerificationEmailProps;

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -4,14 +4,8 @@ import { jwt } from "better-auth/plugins";
 import { nextCookies } from "better-auth/next-js";
 
 import { db } from "../db";
-
-function requireEnv(name: string): string {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(`Missing required environment variable: ${name}`);
-  }
-  return value;
-}
+import { requireEnv } from "@/lib/env";
+import { emailService } from "@/lib/email";
 
 const BETTER_AUTH_URL = requireEnv("BETTER_AUTH_URL");
 const BETTER_AUTH_SECRET = requireEnv("BETTER_AUTH_SECRET");
@@ -35,7 +29,19 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
     minPasswordLength: 12,
-    // TODO: implement sendResetPassword via Resend for forgot-password flow
+    requireEmailVerification: true,
+    sendResetPassword: async ({ user, url, token }) => {
+      // Don't await — keeps response timing constant (no email-exists oracle).
+      void emailService.sendPasswordReset({ to: user.email, url, token });
+    },
+  },
+
+  emailVerification: {
+    sendOnSignUp: true,
+    autoSignInAfterVerification: true,
+    sendVerificationEmail: async ({ user, url, token }) => {
+      void emailService.sendVerificationEmail({ to: user.email, url, token });
+    },
   },
 
   socialProviders: {
@@ -54,18 +60,28 @@ export const auth = betterAuth({
   account: {
     accountLinking: {
       enabled: true,
+      // Auto-link providers sharing an email. Both flags are needed: trustedProviders trusts
+      // the incoming provider, and requireLocalEmailVerified:false lets linking proceed even
+      // when the existing account is unverified (Facebook returns email_verified=false).
       trustedProviders: ["google", "facebook"],
-      // TODO: remove requireLocalEmailVerified:false once Resend email verification is wired up
-      // Both flags are required: trustedProviders clears the provider check, this clears the local-email check
       requireLocalEmailVerified: false,
     },
   },
 
   user: {
     deleteUser: { enabled: true },
-    // Emails aren't verified yet, so a change applies immediately.
-    // TODO: add sendChangeEmailVerification once Resend email verification is wired up
-    changeEmail: { enabled: true },
+    changeEmail: {
+      enabled: true,
+      // Sent to the current address to approve the change before it applies.
+      sendChangeEmailConfirmation: async ({ user, newEmail, url, token }) => {
+        void emailService.sendChangeEmailVerification({
+          to: user.email,
+          url,
+          token,
+          newEmail,
+        });
+      },
+    },
   },
 
   plugins: [

--- a/frontend/src/lib/email/email-service.ts
+++ b/frontend/src/lib/email/email-service.ts
@@ -1,0 +1,47 @@
+import { EmailProvider } from "./provider";
+import VerificationEmail from "@/emails/verification-email";
+import PasswordResetEmail from "@/emails/password-reset-email";
+import ChangeEmailVerification from "@/emails/change-email-verification";
+
+interface TokenEmailArgs {
+  to: string;
+  url: string;
+  token: string;
+}
+
+interface ChangeEmailArgs extends TokenEmailArgs {
+  newEmail: string;
+}
+
+// Provider-agnostic email use cases. Call sites (better-auth hooks, etc.) depend on this,
+// not on Resend, so switching providers only touches the wiring in ./index.
+export class EmailService {
+  constructor(private readonly provider: EmailProvider) {}
+
+  sendVerificationEmail({ to, url, token }: TokenEmailArgs) {
+    return this.provider.send({
+      to,
+      subject: "Potvrdi svoju email adresu",
+      react: VerificationEmail({ verificationUrl: url }),
+      idempotencyKey: `verify-email/${token}`,
+    });
+  }
+
+  sendPasswordReset({ to, url, token }: TokenEmailArgs) {
+    return this.provider.send({
+      to,
+      subject: "Ponovno postavljanje lozinke",
+      react: PasswordResetEmail({ resetUrl: url }),
+      idempotencyKey: `reset-password/${token}`,
+    });
+  }
+
+  sendChangeEmailVerification({ to, url, token, newEmail }: ChangeEmailArgs) {
+    return this.provider.send({
+      to,
+      subject: "Potvrdi promjenu email adrese",
+      react: ChangeEmailVerification({ confirmUrl: url, newEmail }),
+      idempotencyKey: `change-email/${token}`,
+    });
+  }
+}

--- a/frontend/src/lib/email/index.ts
+++ b/frontend/src/lib/email/index.ts
@@ -1,0 +1,12 @@
+import { requireEnv } from "@/lib/env";
+import { EmailService } from "./email-service";
+import { ResendProvider } from "./resend-provider";
+
+// Swap this provider to migrate away from Resend (e.g. an InfobipProvider that implements
+// EmailProvider) — the EmailService and templates stay unchanged.
+const provider = new ResendProvider(
+  requireEnv("RESEND_API_KEY"),
+  requireEnv("EMAIL_FROM"),
+);
+
+export const emailService = new EmailService(provider);

--- a/frontend/src/lib/email/provider.ts
+++ b/frontend/src/lib/email/provider.ts
@@ -1,0 +1,20 @@
+import { ReactElement } from "react";
+
+export interface EmailMessage {
+  to: string;
+  subject: string;
+  react: ReactElement;
+  // Dedupes retries of the same send; providers that don't support it may ignore it.
+  idempotencyKey?: string;
+}
+
+export interface EmailResult {
+  id: string | null;
+  error: string | null;
+}
+
+// Provider-agnostic email transport. Swap implementations (Resend, Infobip, ...)
+// without touching the email service or templates.
+export interface EmailProvider {
+  send(message: EmailMessage): Promise<EmailResult>;
+}

--- a/frontend/src/lib/email/resend-provider.ts
+++ b/frontend/src/lib/email/resend-provider.ts
@@ -1,0 +1,37 @@
+import { Resend } from "resend";
+
+import { EmailMessage, EmailProvider, EmailResult } from "./provider";
+
+export class ResendProvider implements EmailProvider {
+  private readonly client: Resend;
+  private readonly from: string;
+
+  constructor(apiKey: string, from: string) {
+    this.client = new Resend(apiKey);
+    this.from = from;
+  }
+
+  async send({
+    to,
+    subject,
+    react,
+    idempotencyKey,
+  }: EmailMessage): Promise<EmailResult> {
+    // The Resend SDK never throws — it returns { data, error }.
+    const { data, error } = await this.client.emails.send(
+      {
+        from: this.from,
+        to: [to],
+        subject,
+        react,
+      },
+      idempotencyKey ? { idempotencyKey } : undefined,
+    );
+
+    if (error) {
+      return { id: null, error: error.message };
+    }
+
+    return { id: data?.id ?? null, error: null };
+  }
+}

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -1,0 +1,11 @@
+// Reads a required server env var, throwing early (at module load) if it's missing
+// so misconfiguration fails fast instead of at request time.
+export function requireEnv(name: string): string {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return value;
+}


### PR DESCRIPTION
Wire Resend + React Email into Better Auth for verification, password reset, and change-email, enforce email verification, and make all login methods (email/password, Google, Facebook) converge on a single account. Built on a provider-abstracted email layer so the sender (Resend now, Infobip later) is swappable in one place.

Changes:
- Email infrastructure: provider-agnostic email layer (EmailProvider interface + Resend implementation + typed EmailService) and React Email templates (verification, password reset, change-email) sharing one branded layout whose footer always links back to manage email preferences. Adds an `email` preview script and the resend/react-email dependencies.
- Better Auth config: requireEmailVerification (hard gate) with sendOnSignUp + autoSignInAfterVerification; sendResetPassword; user.changeEmail. sendChangeEmailConfirmation; shared requireEnv extracted to lib/env. All email hooks fire-and-forget (void) to keep response timing constant.
- Account linking: keep accountLinking.requireLocalEmailVerified:false so a Google sign-in auto-links to an existing (unverified) Facebook account; clarify the comment explaining why both that and trustedProviders are required.
- Registration: a server endpoint branches by existing-account (anti-enumeration): a new email goes through normal sign-up + verification, an existing account gets a "set password" link via the reset flow (which links a credential for password-less OAuth users) — giving one account all login methods.
- Auth UI: signup shows a "check your inbox" notice instead of logging in; login gains a "forgot password" link and handles the 403 unverified case; new forgot-password form and a /reset-password modal that auto-signs-in after the password is set; auth modal gains a "forgot" mode.
- OAuth error UX: a global OAuthErrorToast (reads ?error= via useSearchParams) surfaces failed sign-in/linking redirects (incl. email_doesn't_match, email_not_found) as localized toasts; linkSocial passes errorCallbackURL.
- Profile modal: disabled "USKORO" placeholders for the future email features (novosti, watchlist discounts, feedback contact).
- Env: add EMAIL_FROM (frontend .env.local + example).

Notes:
- Better Auth's `auth` is a module singleton — Next.js HMR does NOT recreate it on auth.ts edits, so config changes need a dev-server restart (this caused several "stale" debugging detours).
- requireEmailVerification blocks email/password login until verified (OAuth users unaffected); existing unverified email users must verify.
- Facebook accounts are stored with email_verified=false, which is why requireLocalEmailVerified:false is needed for auto-linking and why auto-login after set-password can fall back for Facebook accounts.
- EMAIL_FROM must exactly match a verified Resend domain; Netlify needs RESEND_API_KEY, EMAIL_FROM and FACEBOOK_* set or the build won't boot.
- requireLocalEmailVerified is deprecated in Better Auth; a future-proof fix is to mark OAuth emails verified on user creation instead.
- Two pre-existing react-hooks/set-state-in-effect ESLint errors remain (not introduced here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email and password user registration with email verification
  * Password reset functionality via "Forgot password?" link
  * Transactional email system for account verification and password resets
  * Reset password page accessible from recovery emails

* **Improvements**
  * Enhanced OAuth error handling with user-friendly notifications
  * Profile settings interface for future email management features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->