### PR TITLE
Feat/auth v2

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -19,7 +19,7 @@ FACEBOOK_CLIENT_SECRET=your_facebook_app_secret_here
 # Resend Email API
 RESEND_API_KEY=re_your_resend_api_key_here
 # Sender for transactional emails. Must exactly match a verified Resend domain.
-EMAIL_FROM=Disscount <noreply@disscount.me>
+EMAIL_FROM="Disscount <noreply@disscount.me>"
 
 # Cijene API Configuration
 CIJENE_API_URL=https://api.cijene.dev

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -18,6 +18,8 @@ FACEBOOK_CLIENT_SECRET=your_facebook_app_secret_here
 
 # Resend Email API
 RESEND_API_KEY=re_your_resend_api_key_here
+# Sender for transactional emails. Must exactly match a verified Resend domain.
+EMAIL_FROM=Disscount <noreply@disscount.me>
 
 # Cijene API Configuration
 CIJENE_API_URL=https://api.cijene.dev

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,9 +42,11 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-email": "^6.6.3",
     "react-hook-form": "^7.68.0",
     "react-scan": "^0.4.3",
     "recharts": "2.15.4",
+    "resend": "^6.14.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "zod": "^4.1.13"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "email": "email dev --dir src/emails --port 3366"
   },
   "dependencies": {
     "@daveyplate/better-auth-ui": "^3.2.13",
@@ -47,6 +48,7 @@
     "react-scan": "^0.4.3",
     "recharts": "2.15.4",
     "resend": "^6.14.0",
+    "server-only": "^0.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "zod": "^4.1.13"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      react-email:
+        specifier: ^6.6.3
+        version: 6.6.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-hook-form:
         specifier: ^7.68.0
         version: 7.80.0(react@19.2.4)
@@ -118,6 +121,9 @@ importers:
       recharts:
         specifier: 2.15.4
         version: 2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      resend:
+        specifier: ^6.14.0
+        version: 6.14.0(@react-email/render@2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -230,6 +236,11 @@ packages:
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/parser@7.27.0':
+    resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
@@ -241,6 +252,10 @@ packages:
 
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.27.0':
+    resolution: {integrity: sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.29.7':
@@ -2187,6 +2202,13 @@ packages:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
 
+  '@react-email/render@2.0.9':
+    resolution: {integrity: sha512-M89LiXy2q+9tmQ4VMR0rYGuEe6NJ6HhZsSxBMoLwIia5fVOLcZQcZe2GEO0nAkLZspDjEhn7mtMRPmeMKECEdQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
   '@react-email/row@0.0.13':
     resolution: {integrity: sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw==}
     engines: {node: '>=20.0.0'}
@@ -2268,6 +2290,12 @@ packages:
   '@simplewebauthn/server@13.3.1':
     resolution: {integrity: sha512-GV/oM/qeycWn8p42JZIMJBsXWQcNFg+nJFzeQTnMA4gN8mXg0+HZFWJerHg8ZN/zlveMS3iV1wzuFpOVWS/46w==}
     engines: {node: '>=20.0.0'}
+
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2437,6 +2465,9 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -2503,6 +2534,9 @@ packages:
 
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.61.1':
     resolution: {integrity: sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==}
@@ -2700,6 +2734,10 @@ packages:
       react: ^17 || ^18 || ^19
       react-dom: ^17 || ^18 || ^19
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2718,8 +2756,19 @@ packages:
     resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
     engines: {node: '>= 20'}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -2802,6 +2851,9 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  atomically@2.1.1:
+    resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -2826,6 +2878,10 @@ packages:
 
   barcode-detector@3.2.0:
     resolution: {integrity: sha512-MrT5TT058ptG5YB157pHLfXKVpp0BKEfQBOb8QvzTbatzmLDu85JJ0Gd/sCYwbwdwStJvxsYflrSN6D6E4Ndyw==}
+
+  base64id@2.0.0:
+    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
+    engines: {node: ^4.5.0 || >= 5.9}
 
   baseline-browser-mapping@2.10.38:
     resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
@@ -2968,6 +3024,13 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -3014,6 +3077,10 @@ packages:
   comlink@4.4.2:
     resolution: {integrity: sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==}
 
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
@@ -3029,6 +3096,10 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
+  conf@15.1.0:
+    resolution: {integrity: sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==}
+    engines: {node: '>=20'}
+
   consola@2.15.3:
     resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
 
@@ -3039,6 +3110,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   copy-anything@4.0.5:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
@@ -3046,9 +3121,17 @@ packages:
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
 
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -3115,6 +3198,14 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  debounce-fn@6.0.0:
+    resolution: {integrity: sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==}
+    engines: {node: '>=18'}
+
+  debounce@2.2.0:
+    resolution: {integrity: sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==}
+    engines: {node: '>=18'}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -3193,6 +3284,10 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dot-prop@10.1.0:
+    resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
+    engines: {node: '>=20'}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -3316,6 +3411,14 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
+
+  engine.io@6.6.9:
+    resolution: {integrity: sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==}
+    engines: {node: '>=10.2.0'}
+
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
@@ -3323,6 +3426,10 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   es-abstract-get@1.0.0:
     resolution: {integrity: sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==}
@@ -3554,6 +3661,12 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -3698,6 +3811,10 @@ packages:
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
+
+  globals@11.12.0:
+    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
+    engines: {node: '>=4'}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -3909,6 +4026,10 @@ packages:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -3939,6 +4060,10 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  jiti@2.4.2:
+    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+    hasBin: true
+
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -3964,6 +4089,12 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -3985,6 +4116,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -4096,6 +4231,10 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
+    engines: {node: '>=18'}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -4128,6 +4267,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -4140,9 +4282,21 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -4215,6 +4369,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
   netmask@2.1.1:
     resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
     engines: {node: '>= 0.4.0'}
@@ -4256,6 +4414,15 @@ packages:
   node-releases@2.0.48:
     resolution: {integrity: sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==}
     engines: {node: '>=18'}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  nypm@0.6.6:
+    resolution: {integrity: sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -4340,6 +4507,9 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
@@ -4388,6 +4558,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  picospinner@3.0.0:
+    resolution: {integrity: sha512-lGA1TNsmy2bxvRsTI2cV01kfTwKzZjnZSDmF9llYNyMHMrU4sP87lQ5taiIKm88L3cbswjl008nwyGc3WpNvzg==}
+    engines: {node: '>=18.0.0'}
+
   playwright-core@1.61.0:
     resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
     engines: {node: '>=18'}
@@ -4401,6 +4575,9 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -4441,6 +4618,10 @@ packages:
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
+
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -4504,6 +4685,14 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-email@6.6.3:
+    resolution: {integrity: sha512-kYpkIh00X771MQ4JDKX1Exqj+gRUeNPp/44oHSpo3zvUjnieatpNUu5ssF+me/Ure89J6E6I61ybcr131XDOMw==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
 
   react-google-recaptcha@3.1.0:
     resolution: {integrity: sha512-cYW2/DWas8nEKZGD7SCu9BSuVz8iOcOLHChHyi7upUuVhkpkhYG/6N3KDiTQ3XAiZ2UAZkfvYKMfAHOzBOcGEg==}
@@ -4593,6 +4782,10 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   recharts-scale@0.4.5:
     resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
 
@@ -4614,6 +4807,19 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resend@6.14.0:
+    resolution: {integrity: sha512-jVdpUgOoWGLjaP64lo8KwzHT9gY4w6Dl8c36CIb2F+ayYOMLr3khqs8xrNjXM2k19b+lPoj0VWQFhVNLiToBjA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -4732,6 +4938,17 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
+  socket.io-adapter@2.5.8:
+    resolution: {integrity: sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==}
+
+  socket.io-parser@4.2.6:
+    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io@4.8.3:
+    resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
+    engines: {node: '>=10.2.0'}
+
   socks-proxy-agent@10.1.0:
     resolution: {integrity: sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==}
     engines: {node: '>= 20'}
@@ -4766,6 +4983,9 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -4822,6 +5042,12 @@ packages:
     resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
     engines: {node: '>=18'}
 
+  stubborn-fs@2.0.0:
+    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
+
+  stubborn-utils@1.0.2:
+    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -4868,6 +5094,10 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
@@ -4895,6 +5125,10 @@ packages:
 
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
+
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -5016,6 +5250,10 @@ packages:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
   vaul@1.1.2:
     resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
     peerDependencies:
@@ -5046,6 +5284,9 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  when-exit@2.1.5:
+    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -5080,6 +5321,18 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -5102,6 +5355,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -5194,6 +5451,10 @@ snapshots:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.7
 
+  '@babel/parser@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
@@ -5205,6 +5466,18 @@ snapshots:
       '@babel/code-frame': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
+
+  '@babel/traverse@7.27.0':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/traverse@7.29.7':
     dependencies:
@@ -6993,6 +7266,13 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
+  '@react-email/render@2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.8.4
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@react-email/row@0.0.13(react@19.2.4)':
     dependencies:
       react: 19.2.4
@@ -7047,6 +7327,10 @@ snapshots:
       '@peculiar/asn1-schema': 2.8.0
       '@peculiar/asn1-x509': 2.8.0
       '@peculiar/x509': 1.14.3
+
+  '@socket.io/component-emitter@3.1.2': {}
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -7201,6 +7485,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 25.9.4
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-color@3.1.3': {}
@@ -7264,6 +7552,10 @@ snapshots:
       csstype: 3.2.3
 
   '@types/wrap-ansi@3.0.0': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.4
 
   '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
@@ -7443,6 +7735,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/emscripten'
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -7457,12 +7754,23 @@ snapshots:
 
   agent-base@9.0.0: {}
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-escapes@4.3.2:
     dependencies:
@@ -7569,6 +7877,11 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  atomically@2.1.1:
+    dependencies:
+      stubborn-fs: 2.0.0
+      when-exit: 2.1.5
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -7596,6 +7909,8 @@ snapshots:
       zxing-wasm: 3.1.0(@types/emscripten@1.41.5)
     transitivePeerDependencies:
       - '@types/emscripten'
+
+  base64id@2.0.0: {}
 
   baseline-browser-mapping@2.10.38: {}
 
@@ -7709,6 +8024,12 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  citty@0.2.2: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -7754,6 +8075,8 @@ snapshots:
 
   comlink@4.4.2: {}
 
+  commander@13.1.0: {}
+
   commander@8.3.0: {}
 
   compare-versions@6.1.1: {}
@@ -7769,6 +8092,18 @@ snapshots:
       tree-kill: 1.2.2
       yargs: 18.0.0
 
+  conf@15.1.0:
+    dependencies:
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      atomically: 2.1.1
+      debounce-fn: 6.0.0
+      dot-prop: 10.1.0
+      env-paths: 3.0.0
+      json-schema-typed: 8.0.2
+      semver: 7.8.5
+      uint8array-extras: 1.5.0
+
   consola@2.15.3: {}
 
   console.table@0.10.0:
@@ -7777,17 +8112,29 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@0.7.2: {}
+
   copy-anything@4.0.5:
     dependencies:
       is-what: 5.5.0
 
   core-js@3.49.0: {}
 
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
 
   csstype@3.2.3: {}
 
@@ -7850,6 +8197,12 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  debounce-fn@6.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  debounce@2.2.0: {}
 
   debug@3.2.7:
     dependencies:
@@ -7924,6 +8277,10 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  dot-prop@10.1.0:
+    dependencies:
+      type-fest: 5.7.0
+
   dotenv@17.4.2: {}
 
   drizzle-kit@0.31.10:
@@ -7959,12 +8316,33 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  engine.io-parser@5.2.3: {}
+
+  engine.io@6.6.9:
+    dependencies:
+      '@types/cors': 2.8.19
+      '@types/node': 25.9.4
+      '@types/ws': 8.18.1
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.7.2
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   enhanced-resolve@5.21.6:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
   entities@4.5.0: {}
+
+  env-paths@3.0.0: {}
 
   es-abstract-get@1.0.0:
     dependencies:
@@ -8178,7 +8556,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.2
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
@@ -8201,7 +8579,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8216,14 +8594,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -8238,7 +8616,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -8412,6 +8790,10 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-sha256@1.3.0: {}
+
+  fast-uri@3.1.2: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -8563,6 +8945,8 @@ snapshots:
       minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
+
+  globals@11.12.0: {}
 
   globals@14.0.0: {}
 
@@ -8784,6 +9168,8 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.22
 
+  is-unicode-supported@2.1.0: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -8812,6 +9198,8 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  jiti@2.4.2: {}
+
   jiti@2.7.0: {}
 
   jose@6.2.3: {}
@@ -8827,6 +9215,10 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -8852,6 +9244,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kleur@3.0.3: {}
 
   kleur@4.1.5: {}
 
@@ -8929,6 +9323,11 @@ snapshots:
 
   lodash@4.18.1: {}
 
+  log-symbols@7.0.1:
+    dependencies:
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -8953,6 +9352,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdn-data@2.27.1: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -8962,9 +9363,17 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  mimic-function@5.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -9010,6 +9419,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@0.6.3: {}
+
   netmask@2.1.1: {}
 
   next@16.2.9(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -9048,6 +9459,14 @@ snapshots:
       whatwg-url: 5.0.0
 
   node-releases@2.0.48: {}
+
+  normalize-path@3.0.0: {}
+
+  nypm@0.6.6:
+    dependencies:
+      citty: 0.2.2
+      pathe: 2.0.3
+      tinyexec: 1.2.4
 
   object-assign@4.1.1: {}
 
@@ -9156,6 +9575,8 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
+  pathe@2.0.3: {}
+
   peberminta@0.9.0: {}
 
   pg-cloudflare@1.4.0:
@@ -9199,6 +9620,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  picospinner@3.0.0: {}
+
   playwright-core@1.61.0: {}
 
   playwright@1.61.0:
@@ -9208,6 +9631,8 @@ snapshots:
       fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
+
+  postal-mime@2.7.4: {}
 
   postcss@8.4.31:
     dependencies:
@@ -9238,6 +9663,11 @@ snapshots:
   prettier@3.8.4: {}
 
   prismjs@1.30.0: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
 
   prop-types@15.8.1:
     dependencies:
@@ -9351,6 +9781,37 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-email@6.6.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@babel/traverse': 7.27.0
+      '@react-email/render': 2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      chokidar: 4.0.3
+      commander: 13.1.0
+      conf: 15.1.0
+      css-tree: 3.2.1
+      debounce: 2.2.0
+      esbuild: 0.28.1
+      glob: 13.0.6
+      jiti: 2.4.2
+      log-symbols: 7.0.1
+      marked: 15.0.12
+      mime-types: 3.0.2
+      normalize-path: 3.0.0
+      nypm: 0.6.6
+      picospinner: 3.0.0
+      prismjs: 1.30.0
+      prompts: 2.4.2
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      socket.io: 4.8.3
+      tailwindcss: 4.3.1
+      tsconfig-paths: 4.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   react-google-recaptcha@3.1.0(react@19.2.4):
     dependencies:
       prop-types: 15.8.1
@@ -9446,6 +9907,8 @@ snapshots:
 
   react@19.2.4: {}
 
+  readdirp@4.1.2: {}
+
   recharts-scale@0.4.5:
     dependencies:
       decimal.js-light: 2.5.1
@@ -9484,6 +9947,15 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  require-from-string@2.0.2: {}
+
+  resend@6.14.0(@react-email/render@2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+    dependencies:
+      postal-mime: 2.7.4
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      '@react-email/render': 2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   resolve-from@4.0.0: {}
 
@@ -9641,6 +10113,36 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
+  socket.io-adapter@2.5.8:
+    dependencies:
+      debug: 4.4.3
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.6:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  socket.io@4.8.3:
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io: 6.6.9
+      socket.io-adapter: 2.5.8
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   socks-proxy-agent@10.1.0:
     dependencies:
       agent-base: 9.0.0
@@ -9673,6 +10175,11 @@ snapshots:
   split2@4.2.0: {}
 
   stable-hash@0.0.5: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -9758,6 +10265,12 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
+  stubborn-fs@2.0.0:
+    dependencies:
+      stubborn-utils: 1.0.2
+
+  stubborn-utils@1.0.2: {}
+
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
@@ -9787,6 +10300,8 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -9814,6 +10329,12 @@ snapshots:
     dependencies:
       '@types/json5': 0.0.29
       json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
 
@@ -9968,6 +10489,8 @@ snapshots:
 
   uuid@11.1.1: {}
 
+  vary@1.1.2: {}
+
   vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@radix-ui/react-dialog': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -10018,6 +10541,8 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  when-exit@2.1.5: {}
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -10078,6 +10603,8 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
+  ws@8.21.0: {}
+
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
@@ -10096,6 +10623,8 @@ snapshots:
       yargs-parser: 22.0.0
 
   yocto-queue@0.1.0: {}
+
+  yoctocolors@2.1.2: {}
 
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       resend:
         specifier: ^6.14.0
         version: 6.14.0(@react-email/render@2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      server-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -4879,6 +4882,9 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
@@ -10014,6 +10020,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.5: {}
+
+  server-only@0.0.1: {}
 
   set-cookie-parser@3.1.0: {}
 

--- a/frontend/src/app/api/account/change-email/route.ts
+++ b/frontend/src/app/api/account/change-email/route.ts
@@ -1,0 +1,61 @@
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+import { and, eq, ne } from "drizzle-orm";
+import { z } from "zod";
+
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { account } from "@/db/auth-schema";
+
+const bodySchema = z.object({ newEmail: z.email() });
+
+// Server-side guard for the "one email defines the user" invariant. Changing the account email
+// while a social provider is linked would let a provider login carry a different email than the
+// account — so we block the change until every social account is unlinked, leaving only the
+// password (credential). This holds regardless of which UI calls it.
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const parsed = bodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid email" }, { status: 400 });
+  }
+
+  const requestHeaders = await headers();
+  const session = await auth.api.getSession({ headers: requestHeaders });
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const linkedSocial = await db
+    .select({ id: account.id })
+    .from(account)
+    .where(
+      and(
+        eq(account.userId, session.user.id),
+        ne(account.providerId, "credential"),
+      ),
+    )
+    .limit(1);
+
+  if (linkedSocial.length > 0) {
+    return NextResponse.json({ error: "social_linked" }, { status: 409 });
+  }
+
+  try {
+    // Sends a confirmation to the CURRENT address; the change applies only after it's clicked.
+    await auth.api.changeEmail({
+      body: { newEmail: parsed.data.newEmail.toLowerCase() },
+      headers: requestHeaders,
+    });
+  } catch {
+    return NextResponse.json({ error: "Failed to change email" }, { status: 500 });
+  }
+
+  return NextResponse.json({ status: true });
+}

--- a/frontend/src/app/api/account/register/route.ts
+++ b/frontend/src/app/api/account/register/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { user as userTable } from "@/db/auth-schema";
+import { requireEnv } from "@/lib/env";
+import { passwordSchema } from "@/lib/api/schemas/auth-user";
+
+const registerSchema = z.object({
+  email: z.email(),
+  password: passwordSchema,
+});
+
+// Email+password registration that also works when the email already has a social account.
+// It branches server-side and ALWAYS responds the same way, so account existence never leaks:
+//   - new email       -> normal sign-up, which sends the verification email
+//   - existing account -> a reset link (which links a credential for password-less OAuth users),
+//                         worded as "set" or "reset" depending on the account state.
+// Either way the client just shows a neutral "check your inbox" notice.
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const parsed = registerSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid input" }, { status: 400 });
+  }
+
+  // Better Auth normalizes stored emails to lowercase, so match on the lowercased input.
+  const email = parsed.data.email.toLowerCase();
+
+  try {
+    const existing = await db
+      .select({ id: userTable.id })
+      .from(userTable)
+      .where(eq(userTable.email, email))
+      .limit(1);
+
+    if (existing.length > 0) {
+      await auth.api.requestPasswordReset({
+        body: {
+          email,
+          // Carry the email back so the reset page can sign the user in automatically.
+          redirectTo: `${requireEnv("BETTER_AUTH_URL")}/reset-password?email=${encodeURIComponent(email)}`,
+        },
+      });
+    } else {
+      await auth.api.signUpEmail({
+        body: {
+          email,
+          password: parsed.data.password,
+          name: email.split("@")[0],
+        },
+      });
+    }
+  } catch (error) {
+    // Swallow to keep the response identical regardless of branch/outcome (anti-enumeration);
+    // log server-side so real failures are still observable.
+    console.error("Registration handler failed:", error);
+  }
+
+  return NextResponse.json({ status: true });
+}

--- a/frontend/src/app/api/account/register/route.ts
+++ b/frontend/src/app/api/account/register/route.ts
@@ -46,8 +46,9 @@ export async function POST(request: Request) {
       await auth.api.requestPasswordReset({
         body: {
           email,
-          // Carry the email back so the reset page can sign the user in automatically.
-          redirectTo: `${requireEnv("BETTER_AUTH_URL")}/reset-password?email=${encodeURIComponent(email)}`,
+          // No email in the URL (it would leak via history/Referer/logs); the reset page
+          // works off the token alone and the user logs in after setting the password.
+          redirectTo: `${requireEnv("BETTER_AUTH_URL")}/reset-password`,
         },
       });
     } else {
@@ -60,9 +61,12 @@ export async function POST(request: Request) {
       });
     }
   } catch (error) {
-    // Swallow to keep the response identical regardless of branch/outcome (anti-enumeration);
-    // log server-side so real failures are still observable.
-    console.error("Registration handler failed:", error);
+    // Swallow to keep the response identical regardless of branch/outcome (anti-enumeration).
+    // Log only the error name/type — never the raw error, which can carry the email/password.
+    console.error(
+      "Registration handler failed:",
+      error instanceof Error ? error.name : typeof error,
+    );
   }
 
   return NextResponse.json({ status: true });

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import { AppSidebar } from "@/components/custom/app-sidebar";
 import Header from "@/components/custom/header/header";
 import Footer from "@/components/custom/footer";
+import OAuthErrorToast from "@/components/custom/oauth-error-toast";
 import { Providers } from "@/app/providers/providers";
 import { ReactNode, Suspense } from "react";
 import { sairaStencil } from "@/app/fonts";
@@ -65,6 +66,10 @@ export default function RootLayout({
         className={`${sairaStencil.variable} antialiased bg-zinc-50 relative`}
       >
         <Providers>
+          <Suspense fallback={null}>
+            <OAuthErrorToast />
+          </Suspense>
+
           <div className="min-h-screen flex flex-col w-full">
             {/* pattern background */}
             <div className="absolute inset-0 z-[-15] bg-[url('/+_pattern.png')] bg-repeat opacity-100" />

--- a/frontend/src/app/reset-password/page.tsx
+++ b/frontend/src/app/reset-password/page.tsx
@@ -8,15 +8,16 @@ export const metadata: Metadata = {
 };
 
 interface IPageProps {
-  searchParams?: Promise<{ token?: string; email?: string }>;
+  searchParams?: Promise<{ token?: string | string[] }>;
 }
 
-// The reset/set-password email link lands here as /reset-password?token=...&email=...
-// (Better Auth appends &token=). The modal is rendered over the app, matching the auth dialogs.
+// The reset/set-password email link lands here as /reset-password?token=... (Better Auth
+// appends the token). The modal is rendered over the app, matching the auth dialogs.
 export default async function ResetPasswordPage({ searchParams }: IPageProps) {
   const params = await searchParams;
+  // Next can hand a repeated query param as an array — take the first value.
+  const rawToken = params?.token;
+  const token = Array.isArray(rawToken) ? (rawToken[0] ?? "") : (rawToken ?? "");
 
-  return (
-    <ResetPasswordModal token={params?.token ?? ""} email={params?.email} />
-  );
+  return <ResetPasswordModal token={token} />;
 }

--- a/frontend/src/app/reset-password/page.tsx
+++ b/frontend/src/app/reset-password/page.tsx
@@ -1,0 +1,22 @@
+import { Metadata } from "next";
+
+import ResetPasswordModal from "@/app/reset-password/reset-password-modal";
+
+export const metadata: Metadata = {
+  title: "Nova lozinka",
+  description: "Postavi novu lozinku za svoj Disscount račun.",
+};
+
+interface IPageProps {
+  searchParams?: Promise<{ token?: string; email?: string }>;
+}
+
+// The reset/set-password email link lands here as /reset-password?token=...&email=...
+// (Better Auth appends &token=). The modal is rendered over the app, matching the auth dialogs.
+export default async function ResetPasswordPage({ searchParams }: IPageProps) {
+  const params = await searchParams;
+
+  return (
+    <ResetPasswordModal token={params?.token ?? ""} email={params?.email} />
+  );
+}

--- a/frontend/src/app/reset-password/reset-password-modal.tsx
+++ b/frontend/src/app/reset-password/reset-password-modal.tsx
@@ -26,7 +26,6 @@ import {
 } from "@/components/ui/form";
 import { passwordSchema } from "@/lib/api/schemas/auth-user";
 import { authClient } from "@/lib/auth-client";
-import { useUser } from "@/context/user-context";
 
 const resetPasswordSchema = z
   .object({
@@ -42,18 +41,16 @@ type ResetPasswordForm = z.infer<typeof resetPasswordSchema>;
 
 interface IResetPasswordModalProps {
   token: string;
-  email?: string;
 }
 
 // Opened from the password-reset / set-password email link. Setting the password also creates
 // the credential for OAuth-only users (that's how social accounts gain email login). On success
-// we sign the user in automatically with the new password and send them home.
+// the user is sent to log in — we deliberately don't auto-login, so no email/PII is carried in
+// the reset URL.
 export default function ResetPasswordModal({
   token,
-  email,
 }: IResetPasswordModalProps) {
   const router = useRouter();
-  const { handleUserLogin } = useUser();
 
   const form = useForm<ResetPasswordForm>({
     resolver: zodResolver(resetPasswordSchema),
@@ -61,30 +58,19 @@ export default function ResetPasswordModal({
   });
 
   async function onSubmit(data: ResetPasswordForm) {
-    const { error } = await authClient.resetPassword({
-      newPassword: data.password,
-      token,
-    });
-
-    if (error) {
-      toast.error("Poveznica je nevažeća ili je istekla. Zatraži novu.");
-      return;
-    }
-
-    // Auto-login with the new password when we know the email (OAuth emails are verified, so
-    // this works for Google and Facebook accounts too).
-    if (email) {
-      const { error: signInError } = await authClient.signIn.email({
-        email,
-        password: data.password,
+    try {
+      const { error } = await authClient.resetPassword({
+        newPassword: data.password,
+        token,
       });
 
-      if (!signInError) {
-        await handleUserLogin();
-        toast.success("Lozinka je postavljena. Prijavljen/a si!");
-        router.push("/");
+      if (error) {
+        toast.error("Poveznica je nevažeća ili je istekla. Zatraži novu.");
         return;
       }
+    } catch {
+      toast.error("Greška pri postavljanju lozinke. Pokušaj ponovo.");
+      return;
     }
 
     toast.success("Lozinka je postavljena. Sada se možeš prijaviti.");

--- a/frontend/src/app/reset-password/reset-password-modal.tsx
+++ b/frontend/src/app/reset-password/reset-password-modal.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { z } from "zod";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { PasswordInput } from "@/components/ui/password-input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { passwordSchema } from "@/lib/api/schemas/auth-user";
+import { authClient } from "@/lib/auth-client";
+import { useUser } from "@/context/user-context";
+
+const resetPasswordSchema = z
+  .object({
+    password: passwordSchema,
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Lozinke se ne podudaraju",
+    path: ["confirmPassword"],
+  });
+
+type ResetPasswordForm = z.infer<typeof resetPasswordSchema>;
+
+interface IResetPasswordModalProps {
+  token: string;
+  email?: string;
+}
+
+// Opened from the password-reset / set-password email link. Setting the password also creates
+// the credential for OAuth-only users (that's how social accounts gain email login). On success
+// we sign the user in automatically with the new password and send them home.
+export default function ResetPasswordModal({
+  token,
+  email,
+}: IResetPasswordModalProps) {
+  const router = useRouter();
+  const { handleUserLogin } = useUser();
+
+  const form = useForm<ResetPasswordForm>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: { password: "", confirmPassword: "" },
+  });
+
+  async function onSubmit(data: ResetPasswordForm) {
+    const { error } = await authClient.resetPassword({
+      newPassword: data.password,
+      token,
+    });
+
+    if (error) {
+      toast.error("Poveznica je nevažeća ili je istekla. Zatraži novu.");
+      return;
+    }
+
+    // Auto-login with the new password when we know the email (OAuth emails are verified, so
+    // this works for Google and Facebook accounts too).
+    if (email) {
+      const { error: signInError } = await authClient.signIn.email({
+        email,
+        password: data.password,
+      });
+
+      if (!signInError) {
+        await handleUserLogin();
+        toast.success("Lozinka je postavljena. Prijavljen/a si!");
+        router.push("/");
+        return;
+      }
+    }
+
+    toast.success("Lozinka je postavljena. Sada se možeš prijaviti.");
+    router.push("/");
+  }
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) router.push("/");
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="text-xl">Nova lozinka</DialogTitle>
+          <DialogDescription>
+            Postavi novu lozinku za svoj Disscount račun.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!token ? (
+          <p className="text-sm text-red-700">
+            Nedostaje token. Zatraži novu poveznicu putem „Zaboravljena
+            lozinka?“ na prijavi.
+          </p>
+        ) : (
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="grid gap-4">
+              <FormField
+                control={form.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Nova lozinka</FormLabel>
+                    <FormControl>
+                      <PasswordInput
+                        {...field}
+                        placeholder="••••••••"
+                        autoComplete="new-password"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="confirmPassword"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Potvrdi novu lozinku</FormLabel>
+                    <FormControl>
+                      <PasswordInput
+                        {...field}
+                        placeholder="••••••••"
+                        autoComplete="new-password"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <Button
+                type="submit"
+                size="lg"
+                className="w-full"
+                disabled={form.formState.isSubmitting}
+              >
+                {form.formState.isSubmitting ? (
+                  <Loader2 size={16} className="animate-spin" />
+                ) : (
+                  "Postavi lozinku"
+                )}
+              </Button>
+            </form>
+          </Form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/custom/header/forms/account-credentials-form.tsx
+++ b/frontend/src/components/custom/header/forms/account-credentials-form.tsx
@@ -118,7 +118,7 @@ export default function AccountCredentialsForm({
           currentPassword:
             error.status === 400
               ? "Trenutna lozinka nije točna."
-              : error.message ?? "Greška pri promjeni lozinke.",
+              : (error.message ?? "Greška pri promjeni lozinke."),
         });
         return;
       }
@@ -223,7 +223,6 @@ export default function AccountCredentialsForm({
         {hasPassword && hasLinkedSocial && (
           <p className="text-xs text-muted-foreground">
             Za promjenu emaila prvo odspoji povezane račune (Google, Facebook).
-            Svaki račun ima samo jednu email adresu.
           </p>
         )}
         {errors.email && (
@@ -275,9 +274,7 @@ export default function AccountCredentialsForm({
         </div>
       )}
 
-      {submitError && (
-        <p className="text-xs text-destructive">{submitError}</p>
-      )}
+      {submitError && <p className="text-xs text-destructive">{submitError}</p>}
 
       <Button
         type="submit"
@@ -286,7 +283,11 @@ export default function AccountCredentialsForm({
         disabled={saveDisabled}
         className="w-full"
       >
-        {isSubmitting ? <Loader2 size={16} className="animate-spin" /> : "Spremi"}
+        {isSubmitting ? (
+          <Loader2 size={16} className="animate-spin" />
+        ) : (
+          "Spremi"
+        )}
       </Button>
     </form>
   );

--- a/frontend/src/components/custom/header/forms/account-credentials-form.tsx
+++ b/frontend/src/components/custom/header/forms/account-credentials-form.tsx
@@ -16,6 +16,7 @@ import { useUser } from "@/context/user-context";
 
 interface IAccountCredentialsFormProps {
   hasPassword: boolean;
+  hasLinkedSocial: boolean;
   onChanged: () => void;
 }
 
@@ -27,10 +28,15 @@ interface FieldErrors {
 
 export default function AccountCredentialsForm({
   hasPassword,
+  hasLinkedSocial,
   onChanged,
 }: IAccountCredentialsFormProps) {
   const { user, refreshUser } = useUser();
   const currentEmail = user?.email ?? "";
+
+  // "One email defines the user": the email is editable only with a password AND no social
+  // account linked, so a provider login can never carry a different email than the account.
+  const canEditEmail = hasPassword && !hasLinkedSocial;
 
   const [email, setEmail] = useState(currentEmail);
   const [prevEmail, setPrevEmail] = useState(currentEmail);
@@ -50,7 +56,7 @@ export default function AccountCredentialsForm({
   function validate(): boolean {
     const next: FieldErrors = {};
 
-    if (hasPassword && email !== currentEmail) {
+    if (canEditEmail && email !== currentEmail) {
       if (!z.email().safeParse(email).success) {
         next.email = "Unesi važeći email";
       }
@@ -131,10 +137,23 @@ export default function AccountCredentialsForm({
         }
       }
 
-      const { error } = await authClient.changeEmail({ newEmail: email });
+      // Goes through the guarded endpoint, which enforces "no social linked" server-side.
+      const response = await fetch("/api/account/change-email", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ newEmail: email }),
+      });
 
-      if (error) {
-        setErrors({ email: error.message ?? "Greška pri promjeni emaila." });
+      if (!response.ok) {
+        const data = (await response.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        setErrors({
+          email:
+            data.error === "social_linked"
+              ? "Za promjenu emaila prvo odspoji povezane račune (Google, Facebook)."
+              : "Greška pri promjeni emaila.",
+        });
         return;
       }
     }
@@ -190,7 +209,7 @@ export default function AccountCredentialsForm({
           type="email"
           autoComplete="email"
           value={email}
-          disabled={!hasPassword}
+          disabled={!canEditEmail}
           onChange={(e) => {
             setEmail(e.target.value);
             setErrors((prev) => ({ ...prev, email: undefined }));
@@ -199,6 +218,12 @@ export default function AccountCredentialsForm({
         {!hasPassword && (
           <p className="text-xs text-muted-foreground">
             Postavi lozinku da bi mogao promijeniti email.
+          </p>
+        )}
+        {hasPassword && hasLinkedSocial && (
+          <p className="text-xs text-muted-foreground">
+            Za promjenu emaila prvo odspoji povezane račune (Google, Facebook).
+            Svaki račun ima samo jednu email adresu.
           </p>
         )}
         {errors.email && (

--- a/frontend/src/components/custom/header/forms/account-credentials-form.tsx
+++ b/frontend/src/components/custom/header/forms/account-credentials-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Loader2, Save } from "lucide-react";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -33,15 +33,19 @@ export default function AccountCredentialsForm({
   const currentEmail = user?.email ?? "";
 
   const [email, setEmail] = useState(currentEmail);
+  const [prevEmail, setPrevEmail] = useState(currentEmail);
   const [newPassword, setNewPassword] = useState("");
   const [currentPassword, setCurrentPassword] = useState("");
   const [errors, setErrors] = useState<FieldErrors>({});
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  useEffect(() => {
+  // Sync the editable field when the loaded account email changes — the React-recommended
+  // "adjust state during render" pattern, no effect needed.
+  if (currentEmail !== prevEmail) {
+    setPrevEmail(currentEmail);
     setEmail(currentEmail);
-  }, [currentEmail]);
+  }
 
   function validate(): boolean {
     const next: FieldErrors = {};
@@ -139,7 +143,19 @@ export default function AccountCredentialsForm({
     await refreshUser();
     setNewPassword("");
     setCurrentPassword("");
-    toast.success("Promjene su spremljene!");
+
+    if (emailChanged) {
+      // changeEmail sends a confirmation to the CURRENT address; the new email applies only
+      // after that link is clicked, so revert the field and don't claim it's active yet.
+      setEmail(currentEmail);
+      toast.success(
+        wantPasswordChange
+          ? "Lozinka je promijenjena. Za promjenu emaila potvrdi poveznicu poslanu na tvoju trenutnu adresu."
+          : "Poslali smo poveznicu za potvrdu na tvoju trenutnu email adresu. Promjena emaila primijenit će se nakon potvrde.",
+      );
+    } else {
+      toast.success("Lozinka je promijenjena.");
+    }
   }
 
   async function onSubmit(event: React.FormEvent) {

--- a/frontend/src/components/custom/header/forms/auth-modal.tsx
+++ b/frontend/src/components/custom/header/forms/auth-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useSyncExternalStore } from "react";
 import Link from "next/link";
 import { CircleCheck } from "lucide-react";
 import { toast } from "sonner";
@@ -17,67 +17,61 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { LoginForm } from "@/components/custom/header/forms/login-form";
 import { SignUpForm } from "@/components/custom/header/forms/signup-form";
+import { ForgotPasswordForm } from "@/components/custom/header/forms/forgot-password-form";
 import { GoogleIcon } from "@/components/icons/google-icon";
 import { FacebookIcon } from "@/components/icons/facebook-icon";
 import {
   getLastLoginMethod,
   setLastLoginMethod,
 } from "@/utils/browser/local-storage";
-import { LoginMethod } from "@/typings/local-storage";
 
 interface IAuthModalProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-type AuthMode = "login" | "signup";
+type AuthMode = "login" | "signup" | "forgot";
+
+const TITLES: Record<AuthMode, string> = {
+  login: "Prijava",
+  signup: "Registracija",
+  forgot: "Zaboravljena lozinka",
+};
+
+// Re-read the badge when localStorage changes in another tab; same-tab writes happen right
+// before a redirect, so a no-op there is fine.
+function subscribeToStorage(callback: () => void) {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener("storage", callback);
+  return () => window.removeEventListener("storage", callback);
+}
 
 export function AuthModal({ isOpen, onOpenChange }: IAuthModalProps) {
   const [authMode, setAuthMode] = useState<AuthMode>("login");
-  const [showOnboarding, setShowOnboarding] = useState(false);
-  const [lastLoginMethod, setLastLoginMethodState] = useState<LoginMethod | null>(
-    null,
-  );
   const [socialPending, setSocialPending] = useState<
     "google" | "facebook" | null
   >(null);
 
-  useEffect(() => {
-    setLastLoginMethodState(getLastLoginMethod());
-  }, [isOpen]);
+  // The last-used method lives in localStorage (an external store); reading it via
+  // useSyncExternalStore keeps the badge SSR-safe without a state-setting effect.
+  const lastLoginMethod = useSyncExternalStore(
+    subscribeToStorage,
+    () => getLastLoginMethod(),
+    () => null,
+  );
 
-  // Surface OAuth failures: better-auth redirects to "/" with ?error=<code>.
-  // The only social error we can produce is a Facebook login without email.
-  useEffect(() => {
-    if (typeof window === "undefined") return;
+  // OAuth failures are surfaced by the app-wide <OAuthErrorToast />, not here — account-linking
+  // errors happen while logged in, when this modal isn't mounted.
 
-    const params = new URLSearchParams(window.location.search);
-    const error = params.get("error");
-    if (!error) return;
+  function handleOpenChange(open: boolean) {
+    // Reset to the login tab on close so the next open doesn't show a stale signup/forgot tab.
+    if (!open) setAuthMode("login");
+    onOpenChange(open);
+  }
 
-    toast.error(
-      error === "email_not_found"
-        ? "Tvoj Facebook račun nije podijelio email adresu. Prijavi se emailom ili Facebook računom koji ima email."
-        : "Greška pri prijavi. Pokušaj ponovo.",
-    );
-
-    params.delete("error");
-    const query = params.toString();
-    window.history.replaceState(
-      {},
-      "",
-      window.location.pathname + (query ? `?${query}` : ""),
-    );
-  }, []);
-
-  const handleLoginSuccess = () => {
+  function handleLoginSuccess() {
     onOpenChange(false);
-  };
-
-  const handleSignUpSuccess = () => {
-    onOpenChange(false);
-    setShowOnboarding(true);
-  };
+  }
 
   async function handleSocialSignIn(provider: "google" | "facebook") {
     if (socialPending) return;
@@ -85,7 +79,6 @@ export function AuthModal({ isOpen, onOpenChange }: IAuthModalProps) {
     setSocialPending(provider);
     try {
       setLastLoginMethod(provider);
-      setLastLoginMethodState(provider);
       await signIn.social({
         provider,
         callbackURL: "/",
@@ -98,126 +91,122 @@ export function AuthModal({ isOpen, onOpenChange }: IAuthModalProps) {
     }
   }
 
-  const switchToSignUp = () => {
-    setAuthMode("signup");
-  };
-
-  const switchToLogin = () => {
-    setAuthMode("login");
-  };
-
   return (
-    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle className="text-xl mb-2">
-            {authMode === "login" ? "Prijava" : "Registracija"}
+            {TITLES[authMode]}
           </DialogTitle>
         </DialogHeader>
 
-        <div className="grid gap-8">
-          {authMode === "login" ? (
-            <LoginForm
-              onSuccess={handleLoginSuccess}
-              isLastUsed={lastLoginMethod === "email"}
-              externalDisabled={socialPending !== null}
-            />
-          ) : (
-            <SignUpForm
-              onSuccess={handleSignUpSuccess}
-              externalDisabled={socialPending !== null}
-            />
-          )}
+        {authMode === "forgot" ? (
+          <ForgotPasswordForm onBackToLogin={() => setAuthMode("login")} />
+        ) : (
+          <div className="grid gap-8">
+            {authMode === "login" ? (
+              <LoginForm
+                onSuccess={handleLoginSuccess}
+                onForgotPassword={() => setAuthMode("forgot")}
+                isLastUsed={lastLoginMethod === "email"}
+                externalDisabled={socialPending !== null}
+              />
+            ) : (
+              <SignUpForm externalDisabled={socialPending !== null} />
+            )}
 
-          <div className="relative">
-            <Separator />
+            <div className="relative">
+              <Separator />
 
-            <div className="absolute inset-0 flex items-center justify-center">
-              <span className="bg-background px-4 text-muted-foreground">
-                ili
-              </span>
+              <div className="absolute inset-0 flex items-center justify-center">
+                <span className="bg-background px-4 text-muted-foreground">
+                  ili
+                </span>
+              </div>
             </div>
+
+            <Button
+              variant="outline"
+              size={"lg"}
+              className="w-full gap-4"
+              onClick={() => handleSocialSignIn("google")}
+              disabled={socialPending !== null}
+              loading={socialPending === "google"}
+              icon={GoogleIcon}
+              iconPlacement="left"
+            >
+              Nastavi sa Google računom
+              {lastLoginMethod === "google" && socialPending !== "google" && (
+                <span className="absolute right-3 inline-flex items-center gap-0.5 rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-medium text-white">
+                  <CircleCheck size={9} />
+                  Zadnja prijava
+                </span>
+              )}
+            </Button>
+
+            <Button
+              variant="outline"
+              size={"lg"}
+              className="w-full gap-4"
+              onClick={() => handleSocialSignIn("facebook")}
+              disabled={socialPending !== null}
+              loading={socialPending === "facebook"}
+              icon={FacebookIcon}
+              iconPlacement="left"
+            >
+              Nastavi sa Facebook računom
+              {lastLoginMethod === "facebook" &&
+                socialPending !== "facebook" && (
+                  <span className="absolute right-3 inline-flex items-center gap-0.5 rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-medium text-white">
+                    <CircleCheck size={9} />
+                    Zadnja prijava
+                  </span>
+                )}
+            </Button>
+
+            <p className="text-center text-xs text-muted-foreground text-balance">
+              Nastavkom prihvaćaš naše{" "}
+              <Link
+                href="/terms-of-service"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-primary"
+              >
+                Uvjete korištenja
+              </Link>{" "}
+              i{" "}
+              <Link
+                href="/privacy-policy"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-primary"
+              >
+                Pravila privatnosti
+              </Link>
+              .
+            </p>
           </div>
-
-          <Button
-            variant="outline"
-            size={"lg"}
-            className="w-full gap-4"
-            onClick={() => handleSocialSignIn("google")}
-            disabled={socialPending !== null}
-            loading={socialPending === "google"}
-            icon={GoogleIcon}
-            iconPlacement="left"
-          >
-            Nastavi sa Google računom
-            {lastLoginMethod === "google" && socialPending !== "google" && (
-              <span className="absolute right-3 inline-flex items-center gap-0.5 rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-medium text-white">
-                <CircleCheck size={9} />
-                Zadnja prijava
-              </span>
-            )}
-          </Button>
-
-          <Button
-            variant="outline"
-            size={"lg"}
-            className="w-full gap-4"
-            onClick={() => handleSocialSignIn("facebook")}
-            disabled={socialPending !== null}
-            loading={socialPending === "facebook"}
-            icon={FacebookIcon}
-            iconPlacement="left"
-          >
-            Nastavi sa Facebook računom
-            {lastLoginMethod === "facebook" && socialPending !== "facebook" && (
-              <span className="absolute right-3 inline-flex items-center gap-0.5 rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-medium text-white">
-                <CircleCheck size={9} />
-                Zadnja prijava
-              </span>
-            )}
-          </Button>
-
-          <p className="text-center text-xs text-muted-foreground text-balance">
-            Nastavkom prihvaćaš naše{" "}
-            <Link
-              href="/terms-of-service"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-primary"
-            >
-              Uvjete korištenja
-            </Link>{" "}
-            i{" "}
-            <Link
-              href="/privacy-policy"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-primary"
-            >
-              Pravila privatnosti
-            </Link>
-            .
-          </p>
-        </div>
+        )}
 
         <DialogFooter className="text-xs text-gray-500 text-center my-2 block">
-          {authMode === "login" ? (
+          {authMode === "login" && (
             <>
               Još nemaš račun?{" "}
               <button
                 type="button"
-                onClick={switchToSignUp}
+                onClick={() => setAuthMode("signup")}
                 className="cursor-pointer underline text-primary hover:text-primary/80"
               >
                 Registriraj se
               </button>
             </>
-          ) : (
+          )}
+          {authMode === "signup" && (
             <>
               Već imaš račun?{" "}
               <button
                 type="button"
-                onClick={switchToLogin}
+                onClick={() => setAuthMode("login")}
                 className="cursor-pointer underline text-primary hover:text-primary/80"
               >
                 Prijavi se

--- a/frontend/src/components/custom/header/forms/forgot-password-form.tsx
+++ b/frontend/src/components/custom/header/forms/forgot-password-form.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Loader2 } from "lucide-react";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { authClient } from "@/lib/auth-client";
+import { cn } from "@/lib/utils";
+import InboxNotice from "@/components/custom/header/forms/inbox-notice";
+
+const forgotPasswordSchema = z.object({
+  email: z.email("Unesi važeći email"),
+});
+
+type ForgotPasswordForm = z.infer<typeof forgotPasswordSchema>;
+
+interface IForgotPasswordFormProps {
+  onBackToLogin: () => void;
+}
+
+export function ForgotPasswordForm({ onBackToLogin }: IForgotPasswordFormProps) {
+  const [submittedEmail, setSubmittedEmail] = useState<string | null>(null);
+
+  const form = useForm<ForgotPasswordForm>({
+    resolver: zodResolver(forgotPasswordSchema),
+    defaultValues: { email: "" },
+  });
+
+  async function onSubmit(data: ForgotPasswordForm) {
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? window.location.origin;
+
+    // Carry the email back so the reset page can sign the user in automatically after reset.
+    await authClient.requestPasswordReset({
+      email: data.email,
+      redirectTo: `${appUrl}/reset-password?email=${encodeURIComponent(data.email)}`,
+    });
+
+    // Always show the same notice regardless of outcome — no account-existence enumeration.
+    setSubmittedEmail(data.email);
+  }
+
+  if (submittedEmail) {
+    return (
+      <InboxNotice
+        title="Provjeri svoj inbox"
+        description="Ako račun s tom adresom postoji, poslali smo poveznicu za postavljanje nove lozinke na:"
+        email={submittedEmail}
+      />
+    );
+  }
+
+  return (
+    <form onSubmit={form.handleSubmit(onSubmit)} className="grid gap-4">
+      <p className="text-sm text-muted-foreground">
+        Unesi svoju email adresu i poslat ćemo ti poveznicu za postavljanje nove
+        lozinke.
+      </p>
+
+      <div className="grid gap-2">
+        <Label htmlFor="forgot-email">Email</Label>
+        <Input
+          id="forgot-email"
+          type="email"
+          placeholder="korisnik@example.com"
+          autoComplete="email"
+          {...form.register("email")}
+          className={cn(form.formState.errors.email && "border-red-700")}
+        />
+        {form.formState.errors.email && (
+          <p className="text-sm text-red-700">
+            {form.formState.errors.email.message}
+          </p>
+        )}
+      </div>
+
+      <Button
+        type="submit"
+        size="lg"
+        className="w-full"
+        disabled={form.formState.isSubmitting}
+      >
+        {form.formState.isSubmitting ? (
+          <Loader2 size={16} className="animate-spin" />
+        ) : (
+          "Pošalji poveznicu"
+        )}
+      </Button>
+
+      <button
+        type="button"
+        onClick={onBackToLogin}
+        className="cursor-pointer text-sm text-primary underline hover:text-primary/80"
+      >
+        Natrag na prijavu
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/custom/header/forms/forgot-password-form.tsx
+++ b/frontend/src/components/custom/header/forms/forgot-password-form.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
 import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
@@ -34,13 +35,20 @@ export function ForgotPasswordForm({ onBackToLogin }: IForgotPasswordFormProps) 
   async function onSubmit(data: ForgotPasswordForm) {
     const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? window.location.origin;
 
-    // Carry the email back so the reset page can sign the user in automatically after reset.
-    await authClient.requestPasswordReset({
-      email: data.email,
-      redirectTo: `${appUrl}/reset-password?email=${encodeURIComponent(data.email)}`,
-    });
+    try {
+      // No email in the URL (it would leak via history/Referer/logs); the link carries the token.
+      await authClient.requestPasswordReset({
+        email: data.email,
+        redirectTo: `${appUrl}/reset-password`,
+      });
+    } catch {
+      // Only a thrown transport/runtime failure reaches here; API-level { error } is intentionally
+      // ignored so the response can't reveal whether the account exists.
+      toast.error("Greška pri slanju poveznice. Pokušaj ponovo.");
+      return;
+    }
 
-    // Always show the same notice regardless of outcome — no account-existence enumeration.
+    // Same notice regardless of whether the account exists — no enumeration.
     setSubmittedEmail(data.email);
   }
 

--- a/frontend/src/components/custom/header/forms/inbox-notice.tsx
+++ b/frontend/src/components/custom/header/forms/inbox-notice.tsx
@@ -1,0 +1,34 @@
+import { MailCheck } from "lucide-react";
+
+interface IInboxNoticeProps {
+  title: string;
+  description: string;
+  email?: string;
+}
+
+// Neutral "go check your inbox" panel shown after any action that sends an email
+// (signup verification, password reset request). Worded so it never reveals whether the
+// address has an account.
+export default function InboxNotice({
+  title,
+  description,
+  email,
+}: IInboxNoticeProps) {
+  return (
+    <div className="flex flex-col items-center gap-3 py-4 text-center">
+      <div className="flex size-12 items-center justify-center rounded-full bg-green-100 text-primary">
+        <MailCheck className="size-6" />
+      </div>
+
+      <h3 className="text-lg font-semibold">{title}</h3>
+
+      <p className="text-sm text-muted-foreground">{description}</p>
+
+      {email && <p className="text-sm font-medium">{email}</p>}
+
+      <p className="text-xs text-muted-foreground">
+        Ne zaboravi provjeriti i spam / neželjenu poštu.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/custom/header/forms/linked-accounts.tsx
+++ b/frontend/src/components/custom/header/forms/linked-accounts.tsx
@@ -44,10 +44,13 @@ export default function LinkedAccounts({
   async function handleLink(provider: SocialProvider) {
     setPending(provider);
     try {
-      // Redirects to the provider and back; the account is linked on return.
+      // Redirects to the provider and back; the account is linked on return. On failure
+      // (e.g. the provider's email doesn't match this account) Better Auth redirects to
+      // errorCallbackURL with ?error=, which the app-wide OAuthErrorToast surfaces.
       await authClient.linkSocial({
         provider,
         callbackURL: window.location.pathname,
+        errorCallbackURL: window.location.pathname,
       });
     } catch {
       toast.error("Greška pri povezivanju računa.");

--- a/frontend/src/components/custom/header/forms/login-form.tsx
+++ b/frontend/src/components/custom/header/forms/login-form.tsx
@@ -25,11 +25,17 @@ import { PasswordInput } from "@/components/ui/password-input";
 
 interface ILoginFormProps {
   onSuccess?: () => void;
+  onForgotPassword: () => void;
   isLastUsed?: boolean;
   externalDisabled?: boolean;
 }
 
-export function LoginForm({ onSuccess, isLastUsed, externalDisabled }: ILoginFormProps) {
+export function LoginForm({
+  onSuccess,
+  onForgotPassword,
+  isLastUsed,
+  externalDisabled,
+}: ILoginFormProps) {
   const { handleUserLogin } = useUser();
 
   const form = useForm<LoginRequest>({
@@ -51,10 +57,16 @@ export function LoginForm({ onSuccess, isLastUsed, externalDisabled }: ILoginFor
 
       if (result.error) {
         const status = result.error.status ?? 0;
-        const message =
-          status === 401 || status === 400
-            ? "Neispravni email ili lozinka"
-            : result.error.message || "Provjeri unesene podatke.";
+        let message: string;
+        if (status === 403) {
+          // Email not verified — Better Auth re-sends the verification link on each attempt.
+          message =
+            "Tvoj email još nije potvrđen. Poslali smo ti novu poveznicu — provjeri inbox (i spam).";
+        } else if (status === 401 || status === 400) {
+          message = "Neispravni email ili lozinka";
+        } else {
+          message = result.error.message || "Provjeri unesene podatke.";
+        }
         form.setError("root", { type: "server", message });
         return;
       }
@@ -119,6 +131,14 @@ export function LoginForm({ onSuccess, isLastUsed, externalDisabled }: ILoginFor
             </FormItem>
           )}
         />
+
+        <button
+          type="button"
+          onClick={onForgotPassword}
+          className="-mt-2 justify-self-end cursor-pointer text-sm text-primary underline hover:text-primary/80"
+        >
+          Zaboravljena lozinka?
+        </button>
 
         <Button type="submit" size="lg" className="w-full" disabled={form.formState.isSubmitting || externalDisabled}>
           {form.formState.isSubmitting ? (

--- a/frontend/src/components/custom/header/forms/security-modal.tsx
+++ b/frontend/src/components/custom/header/forms/security-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import {
   Trash2,
   LogOut,
@@ -11,7 +11,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { toast } from "sonner";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { isAxiosError } from "axios";
 
 import {
@@ -75,35 +75,29 @@ export default function SecurityModal({
   const [showLogoutAllConfirm, setShowLogoutAllConfirm] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
-  const [accounts, setAccounts] = useState<LinkedAccount[]>([]);
-  const [accountsStatus, setAccountsStatus] = useState<
-    "loading" | "loaded" | "error"
-  >("loading");
-
-  const loadAccounts = useCallback(async () => {
-    setAccountsStatus("loading");
-
-    try {
+  // Fetch linked accounts when the modal opens (React Query, the codebase standard) — no
+  // state-setting effect. reloadAccounts is handed to children to refresh after link/unlink.
+  const {
+    data: accounts = [],
+    status: accountsStatus,
+    refetch: reloadAccounts,
+  } = useQuery({
+    queryKey: ["linked-accounts"],
+    enabled: isOpen,
+    queryFn: async (): Promise<LinkedAccount[]> => {
       const { data, error } = await authClient.listAccounts();
       if (error || !data) {
-        setAccountsStatus("error");
-        return;
+        throw new Error("Failed to load accounts");
       }
-
-      setAccounts(
-        data.map((a) => ({ providerId: a.providerId, accountId: a.accountId })),
-      );
-      setAccountsStatus("loaded");
-    } catch {
-      setAccountsStatus("error");
-    }
-  }, []);
-
-  useEffect(() => {
-    if (isOpen) loadAccounts();
-  }, [isOpen, loadAccounts]);
+      return data.map((a) => ({
+        providerId: a.providerId,
+        accountId: a.accountId,
+      }));
+    },
+  });
 
   const hasPassword = accounts.some((a) => a.providerId === "credential");
+  const hasLinkedSocial = accounts.some((a) => a.providerId !== "credential");
 
   async function handleLogoutAll() {
     setIsRevoking(true);
@@ -181,7 +175,7 @@ export default function SecurityModal({
           </DialogHeader>
 
           <div className="flex flex-col gap-6">
-            {accountsStatus === "loading" && (
+            {accountsStatus === "pending" && (
               <div className="flex justify-center py-6">
                 <Loader2 className="size-5 animate-spin text-primary" />
               </div>
@@ -193,7 +187,7 @@ export default function SecurityModal({
               </p>
             )}
 
-            {accountsStatus === "loaded" && (
+            {accountsStatus === "success" && (
               <>
                 <section className="space-y-3">
                   <SectionLabel icon={ShieldCheck}>
@@ -202,13 +196,14 @@ export default function SecurityModal({
 
                   <AccountCredentialsForm
                     hasPassword={hasPassword}
-                    onChanged={loadAccounts}
+                    hasLinkedSocial={hasLinkedSocial}
+                    onChanged={reloadAccounts}
                   />
                 </section>
 
                 <section className="space-y-3">
                   <SectionLabel icon={Link2}>Povezani računi</SectionLabel>
-                  <LinkedAccounts accounts={accounts} onChanged={loadAccounts} />
+                  <LinkedAccounts accounts={accounts} onChanged={reloadAccounts} />
                 </section>
               </>
             )}

--- a/frontend/src/components/custom/header/forms/signup-form.tsx
+++ b/frontend/src/components/custom/header/forms/signup-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Loader2 } from "lucide-react";
@@ -17,19 +18,21 @@ import {
   Form,
 } from "@/components/ui/form";
 import { PasswordInput } from "@/components/ui/password-input";
-import { registerRequestSchema, RegisterRequest } from "@/lib/api/schemas/auth-user";
+import {
+  registerRequestSchema,
+  RegisterRequest,
+} from "@/lib/api/schemas/auth-user";
 import { cn } from "@/lib/utils";
-import { signUp } from "@/lib/auth-client";
-import { useUser } from "@/context/user-context";
-import { setLastLoginMethod } from "@/utils/browser/local-storage";
+import InboxNotice from "@/components/custom/header/forms/inbox-notice";
 
 interface ISignUpFormProps {
-  onSuccess?: () => void;
   externalDisabled?: boolean;
 }
 
-export function SignUpForm({ onSuccess, externalDisabled }: ISignUpFormProps) {
-  const { handleUserLogin } = useUser();
+export function SignUpForm({ externalDisabled }: ISignUpFormProps) {
+  // Set once registration succeeds. Email verification is required, so we don't log in —
+  // we show a "check your inbox" notice instead.
+  const [submittedEmail, setSubmittedEmail] = useState<string | null>(null);
 
   const form = useForm<RegisterRequest>({
     resolver: zodResolver(registerRequestSchema),
@@ -44,29 +47,37 @@ export function SignUpForm({ onSuccess, externalDisabled }: ISignUpFormProps) {
     form.clearErrors("root");
 
     try {
-      const result = await signUp.email({
-        name: data.email.split("@")[0],
-        email: data.email,
-        password: data.password,
+      // The endpoint always responds the same way (no account-existence enumeration):
+      // a new email gets a verification link, an existing account a "set/reset password" link.
+      const response = await fetch("/api/account/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: data.email, password: data.password }),
       });
 
-      if (result.error) {
-        const message =
-          result.error.status === 422
-            ? "Korisnik s tim emailom već postoji"
-            : result.error.message || "Provjeri unesene podatke.";
-        form.setError("root", { type: "server", message });
+      if (!response.ok) {
+        form.setError("root", {
+          type: "server",
+          message: "Provjeri unesene podatke.",
+        });
         return;
       }
 
-      await handleUserLogin();
-      toast.success("Uspješno ste se registrirali!");
+      setSubmittedEmail(data.email);
       form.reset();
-      setLastLoginMethod("email");
-      onSuccess?.();
     } catch {
       toast.error("Greška pri registraciji. Pokušaj ponovo.");
     }
+  }
+
+  if (submittedEmail) {
+    return (
+      <InboxNotice
+        title="Provjeri svoj inbox"
+        description="Poslali smo ti email s poveznicom za dovršetak registracije na:"
+        email={submittedEmail}
+      />
+    );
   }
 
   return (
@@ -111,7 +122,7 @@ export function SignUpForm({ onSuccess, externalDisabled }: ISignUpFormProps) {
                   placeholder="••••••••"
                   autoComplete="new-password"
                   className={cn(
-                    form.formState.errors.password && "border-red-700"
+                    form.formState.errors.password && "border-red-700",
                   )}
                 />
               </FormControl>
@@ -132,7 +143,7 @@ export function SignUpForm({ onSuccess, externalDisabled }: ISignUpFormProps) {
                   placeholder="••••••••"
                   autoComplete="new-password"
                   className={cn(
-                    form.formState.errors.confirmPassword && "border-red-700"
+                    form.formState.errors.confirmPassword && "border-red-700",
                   )}
                 />
               </FormControl>
@@ -141,7 +152,12 @@ export function SignUpForm({ onSuccess, externalDisabled }: ISignUpFormProps) {
           )}
         />
 
-        <Button type="submit" size="lg" className="w-full" disabled={form.formState.isSubmitting || externalDisabled}>
+        <Button
+          type="submit"
+          size="lg"
+          className="w-full"
+          disabled={form.formState.isSubmitting || externalDisabled}
+        >
           {form.formState.isSubmitting ? (
             <Loader2 size={16} className="animate-spin" />
           ) : (

--- a/frontend/src/components/custom/oauth-error-toast.tsx
+++ b/frontend/src/components/custom/oauth-error-toast.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+import { toast } from "sonner";
+
+// Better Auth appends ?error=<code> to the redirect when a social sign-in or account-linking
+// flow fails. Map the codes we can produce to localized, friendly messages.
+const ERROR_MESSAGES: Record<string, string> = {
+  email_not_found:
+    "Tvoj Facebook račun nije podijelio email adresu. Prijavi se emailom ili Facebook računom koji ima email.",
+  "email_doesn't_match":
+    "Taj račun koristi drugu email adresu. Možeš povezati samo račune s istom email adresom.",
+  account_not_linked:
+    "Ovu prijavu nije moguće povezati s postojećim računom. Prijavi se postojećom metodom pa poveži račun u postavkama.",
+};
+
+const DEFAULT_MESSAGE = "Došlo je do greške pri prijavi. Pokušaj ponovo.";
+
+// Surfaces failed OAuth flows (social sign-in OR account linking) as a toast, mounted app-wide.
+// Account-linking errors happen while logged in, so this must live outside the auth modal that
+// only logged-out users render. Reads ?error= from Next's router snapshot (useSearchParams)
+// rather than window.location, which loses a race against a URL rewrite during session load.
+export default function OAuthErrorToast() {
+  const searchParams = useSearchParams();
+  const error = searchParams.get("error");
+  const shown = useRef(false);
+
+  useEffect(() => {
+    if (!error || shown.current) return;
+
+    shown.current = true;
+    toast.error(ERROR_MESSAGES[error] ?? DEFAULT_MESSAGE, { duration: 6000 });
+
+    // Strip the param from the address bar so a refresh doesn't re-show the toast.
+    const params = new URLSearchParams(window.location.search);
+    params.delete("error");
+    params.delete("error_description");
+    const query = params.toString();
+    window.history.replaceState(
+      {},
+      "",
+      window.location.pathname + (query ? `?${query}` : ""),
+    );
+  }, [error]);
+
+  return null;
+}

--- a/frontend/src/components/custom/oauth-error-toast.tsx
+++ b/frontend/src/components/custom/oauth-error-toast.tsx
@@ -5,14 +5,22 @@ import { useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
 // Better Auth appends ?error=<code> to the redirect when a social sign-in or account-linking
-// flow fails. Map the codes we can produce to localized, friendly messages.
+// flow fails. Map every code we can hit to a localized, specific message so the user always
+// learns WHY (rather than a generic "something went wrong").
 const ERROR_MESSAGES: Record<string, string> = {
   email_not_found:
     "Tvoj Facebook račun nije podijelio email adresu. Prijavi se emailom ili Facebook računom koji ima email.",
+  // Linking flow: the provider's email differs from the logged-in account's email.
   "email_doesn't_match":
-    "Taj račun koristi drugu email adresu. Možeš povezati samo račune s istom email adresom.",
+    "Povezivanje nije uspjelo jer taj račun koristi drugu email adresu. Možeš povezati samo račune koji imaju istu email adresu kao tvoj.",
+  // Linking flow: that exact provider account already belongs to another Disscount user.
+  account_already_linked_to_different_user:
+    "Taj račun je već povezan s drugim Disscount korisnikom. Ne možeš ga povezati s ovim računom.",
+  // Sign-in flow: a matching account exists but can't be auto-linked under current rules.
   account_not_linked:
-    "Ovu prijavu nije moguće povezati s postojećim računom. Prijavi se postojećom metodom pa poveži račun u postavkama.",
+    "Ovu prijavu nije moguće automatski povezati s postojećim računom. Prijavi se postojećom metodom pa poveži račun u postavkama sigurnosti.",
+  please_restart_the_process:
+    "Postupak prijave je istekao ili je prekinut. Pokušaj ponovo.",
 };
 
 const DEFAULT_MESSAGE = "Došlo je do greške pri prijavi. Pokušaj ponovo.";

--- a/frontend/src/emails/change-email-confirmation.tsx
+++ b/frontend/src/emails/change-email-confirmation.tsx
@@ -1,0 +1,35 @@
+import ActionEmail from "./components/action-email";
+
+interface IChangeEmailConfirmationProps {
+  confirmUrl: string;
+  newEmail: string;
+}
+
+// Sent to the user's CURRENT address to approve a change before it applies, so a hijacked
+// session can't silently move the account to an attacker's email.
+export default function ChangeEmailConfirmation({
+  confirmUrl,
+  newEmail,
+}: IChangeEmailConfirmationProps) {
+  return (
+    <ActionEmail
+      preview="Potvrdi promjenu email adrese"
+      heading="Potvrdi promjenu email adrese"
+      intro={
+        <>
+          Zatražena je promjena email adrese tvog Disscount računa na{" "}
+          <span className="font-semibold text-gray-800">{newEmail}</span>.
+          Klikni na gumb ispod kako bi potvrdio/la promjenu.
+        </>
+      }
+      buttonLabel="Potvrdi promjenu"
+      buttonUrl={confirmUrl}
+      footnote="Ako nisi ti zatražio/la ovu promjenu, odmah promijeni lozinku i javi nam se — tvoja adresa ostaje nepromijenjena dok ne potvrdiš."
+    />
+  );
+}
+
+ChangeEmailConfirmation.PreviewProps = {
+  confirmUrl: "https://disscount.me/api/auth/verify-email?token=preview",
+  newEmail: "nova@email.com",
+} satisfies IChangeEmailConfirmationProps;

--- a/frontend/src/emails/components/action-email.tsx
+++ b/frontend/src/emails/components/action-email.tsx
@@ -1,0 +1,53 @@
+import { ReactNode } from "react";
+import { Button, Link, Section, Text } from "react-email";
+
+import EmailLayout from "./email-layout";
+
+interface IActionEmailProps {
+  preview: string;
+  heading: string;
+  intro: ReactNode;
+  buttonLabel: string;
+  buttonUrl: string;
+  footnote: string;
+}
+
+// Shared layout for the single-call-to-action transactional emails (verification, password
+// reset, set password, change-email confirmation): a heading, intro copy, one branded button,
+// a plain-text fallback link, and a closing footnote.
+export default function ActionEmail({
+  preview,
+  heading,
+  intro,
+  buttonLabel,
+  buttonUrl,
+  footnote,
+}: IActionEmailProps) {
+  return (
+    <EmailLayout preview={preview}>
+      <Text className="m-0 mb-2 text-xl font-bold text-gray-800">{heading}</Text>
+
+      <Text className="m-0 mb-6 text-sm leading-relaxed text-gray-600">
+        {intro}
+      </Text>
+
+      <Section className="mb-6">
+        <Button
+          href={buttonUrl}
+          className="box-border rounded-md bg-brand px-6 py-3 text-center text-sm font-semibold text-white no-underline"
+        >
+          {buttonLabel}
+        </Button>
+      </Section>
+
+      <Text className="m-0 mb-6 text-xs text-gray-500">
+        Ako gumb ne radi, kopiraj i zalijepi ovu poveznicu u preglednik:{" "}
+        <Link href={buttonUrl} className="break-all text-brand underline">
+          {buttonUrl}
+        </Link>
+      </Text>
+
+      <Text className="m-0 text-xs text-gray-500">{footnote}</Text>
+    </EmailLayout>
+  );
+}

--- a/frontend/src/emails/components/email-layout.tsx
+++ b/frontend/src/emails/components/email-layout.tsx
@@ -1,0 +1,67 @@
+import { ReactNode } from "react";
+import {
+  Body,
+  Container,
+  Head,
+  Hr,
+  Html,
+  Link,
+  Preview,
+  Tailwind,
+  Text,
+  pixelBasedPreset,
+} from "react-email";
+
+// Accessible representative of the app's green --primary (oklch ~141 hue) as a hex email
+// clients understand. Deep enough that white button text stays legible.
+const BRAND = "#16a34a";
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? "https://disscount.me";
+
+interface IEmailLayoutProps {
+  preview: string;
+  children: ReactNode;
+}
+
+// Shared shell for every transactional email: brand wordmark, the message body, and a footer
+// that always links back to the app where the user can manage their email preferences.
+export default function EmailLayout({ preview, children }: IEmailLayoutProps) {
+  return (
+    <Html lang="hr">
+      <Tailwind
+        config={{
+          presets: [pixelBasedPreset],
+          theme: { extend: { colors: { brand: BRAND } } },
+        }}
+      >
+        <Head />
+        <Body className="bg-gray-100 font-sans">
+          <Preview>{preview}</Preview>
+
+          <Container className="mx-auto my-8 max-w-xl rounded-lg border border-solid border-gray-200 bg-white p-8">
+            <Text className="m-0 mb-6 text-2xl font-bold text-brand">
+              disscount
+            </Text>
+
+            {children}
+
+            <Hr className="my-6 border-solid border-gray-200" />
+
+            <Text className="m-0 text-xs text-gray-500">
+              Ovaj email primaš jer postoji račun na Disscountu povezan s ovom
+              adresom. Email postavke možeš promijeniti kada se{" "}
+              <Link href={APP_URL} className="text-brand underline">
+                prijaviš na Disscount
+              </Link>
+              .
+            </Text>
+
+            <Text className="m-0 mt-2 text-xs text-gray-400">
+              © {new Date().getFullYear()} Disscount
+            </Text>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+}

--- a/frontend/src/emails/password-reset-email.tsx
+++ b/frontend/src/emails/password-reset-email.tsx
@@ -1,0 +1,24 @@
+import ActionEmail from "./components/action-email";
+
+interface IPasswordResetEmailProps {
+  resetUrl: string;
+}
+
+export default function PasswordResetEmail({
+  resetUrl,
+}: IPasswordResetEmailProps) {
+  return (
+    <ActionEmail
+      preview="Ponovno postavi svoju lozinku za Disscount"
+      heading="Ponovno postavljanje lozinke"
+      intro="Zatražio/la si ponovno postavljanje lozinke. Klikni na gumb ispod kako bi postavio/la novu lozinku. Poveznica vrijedi ograničeno vrijeme."
+      buttonLabel="Postavi novu lozinku"
+      buttonUrl={resetUrl}
+      footnote="Ako nisi ti zatražio/la ovu promjenu, zanemari ovaj email — tvoja lozinka ostaje nepromijenjena."
+    />
+  );
+}
+
+PasswordResetEmail.PreviewProps = {
+  resetUrl: "https://disscount.me/reset-password?token=preview",
+} satisfies IPasswordResetEmailProps;

--- a/frontend/src/emails/set-password-email.tsx
+++ b/frontend/src/emails/set-password-email.tsx
@@ -1,0 +1,27 @@
+import ActionEmail from "./components/action-email";
+
+interface ISetPasswordEmailProps {
+  setPasswordUrl: string;
+}
+
+// Sent when someone registers with an email that already has an OAuth-only account
+// (Google/Facebook) but no password. Wording reads as "finish setting up" rather than
+// "reset", since they are adding email/password login for the first time.
+export default function SetPasswordEmail({
+  setPasswordUrl,
+}: ISetPasswordEmailProps) {
+  return (
+    <ActionEmail
+      preview="Postavi lozinku za svoj Disscount račun"
+      heading="Postavi lozinku za svoj račun"
+      intro="Za ovu email adresu već postoji Disscount račun (prijava putem Googlea ili Facebooka). Klikni na gumb ispod kako bi postavio/la lozinku i ubuduće se mogao/la prijaviti i emailom. Poveznica vrijedi ograničeno vrijeme."
+      buttonLabel="Postavi lozinku"
+      buttonUrl={setPasswordUrl}
+      footnote="Ako nisi ti zatražio/la ovo, zanemari ovaj email — tvoj račun ostaje nepromijenjen."
+    />
+  );
+}
+
+SetPasswordEmail.PreviewProps = {
+  setPasswordUrl: "https://disscount.me/reset-password?token=preview",
+} satisfies ISetPasswordEmailProps;

--- a/frontend/src/emails/verification-email.tsx
+++ b/frontend/src/emails/verification-email.tsx
@@ -1,0 +1,24 @@
+import ActionEmail from "./components/action-email";
+
+interface IVerificationEmailProps {
+  verificationUrl: string;
+}
+
+export default function VerificationEmail({
+  verificationUrl,
+}: IVerificationEmailProps) {
+  return (
+    <ActionEmail
+      preview="Potvrdi svoju email adresu za Disscount"
+      heading="Potvrdi svoju email adresu"
+      intro="Hvala na registraciji! Klikni na gumb ispod kako bi potvrdio/la svoju email adresu i aktivirao/la svoj Disscount račun."
+      buttonLabel="Potvrdi email"
+      buttonUrl={verificationUrl}
+      footnote="Ako nisi ti zatražio/la ovaj račun, slobodno zanemari ovaj email."
+    />
+  );
+}
+
+VerificationEmail.PreviewProps = {
+  verificationUrl: "https://disscount.me/api/auth/verify-email?token=preview",
+} satisfies IVerificationEmailProps;

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -2,7 +2,8 @@ import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { jwt } from "better-auth/plugins";
 import { nextCookies } from "better-auth/next-js";
-import { and, eq } from "drizzle-orm";
+import { APIError } from "better-auth/api";
+import { and, eq, ne } from "drizzle-orm";
 
 import { db } from "../db";
 import { account } from "../db/auth-schema";
@@ -42,6 +43,29 @@ async function dispatchResetPasswordEmail(
   }
 }
 
+// Returns whether the user has any non-credential (social) account linked. Used to enforce the
+// "one email defines the user" invariant.
+async function hasLinkedSocialAccount(userId: string): Promise<boolean> {
+  const rows = await db
+    .select({ id: account.id })
+    .from(account)
+    .where(and(eq(account.userId, userId), ne(account.providerId, "credential")))
+    .limit(1);
+
+  return rows.length > 0;
+}
+
+// Non-PII rejection handler for the fire-and-forget email sends, so a failed dispatch surfaces
+// in logs instead of becoming an unhandled rejection (without logging recipient addresses).
+function logEmailFailure(kind: string) {
+  return (error: unknown) => {
+    console.error(
+      `Failed to send ${kind} email:`,
+      error instanceof Error ? error.name : typeof error,
+    );
+  };
+}
+
 export const auth = betterAuth({
   baseURL: BETTER_AUTH_URL,
   secret: BETTER_AUTH_SECRET,
@@ -64,8 +88,11 @@ export const auth = betterAuth({
     revokeSessionsOnPasswordReset: true,
     sendResetPassword: async ({ user, url, token }) => {
       // Fire-and-forget so the response time is identical whether or not the email exists
-      // (no enumeration oracle). The DB lookup runs inside the un-awaited task.
-      void dispatchResetPasswordEmail(user.id, user.email, url, token);
+      // (no enumeration oracle). The DB lookup runs inside the un-awaited task; .catch keeps a
+      // failed send from becoming an unhandled rejection.
+      void dispatchResetPasswordEmail(user.id, user.email, url, token).catch(
+        logEmailFailure("password-reset"),
+      );
     },
   },
 
@@ -73,7 +100,9 @@ export const auth = betterAuth({
     sendOnSignUp: true,
     autoSignInAfterVerification: true,
     sendVerificationEmail: async ({ user, url, token }) => {
-      void emailService.sendVerificationEmail({ to: user.email, url, token });
+      void emailService
+        .sendVerificationEmail({ to: user.email, url, token })
+        .catch(logEmailFailure("verification"));
     },
   },
 
@@ -102,18 +131,39 @@ export const auth = betterAuth({
   },
 
   databaseHooks: {
-    user: {
+    account: {
       create: {
-        // OAuth providers (Google, Facebook) are trusted to own the email, so mark it verified
-        // on creation. This keeps requireEmailVerification's gate intact for email/password
-        // sign-ups (which must verify) while letting social accounts auto-link and auto-login.
-        // Facebook is the key case: it returns no email-verified claim, so without this it would
-        // be stored unverified and block linking.
-        before: async (user, ctx) => {
-          const isEmailSignup = ctx?.path === "/sign-up/email";
+        // Positive OAuth signal: when a social account is created (sign-up or linking), mark the
+        // user's email verified — the provider owns the email. Credential accounts are skipped,
+        // so email/password sign-ups keep requireEmailVerification's gate. Google already arrives
+        // verified; this is what makes Facebook (which returns no verified claim) work without
+        // the deprecated requireLocalEmailVerified flag, and it can't accidentally verify a
+        // credential signup (unlike a path-based check).
+        after: async (createdAccount, ctx) => {
+          if (!ctx || createdAccount.providerId === "credential") return;
 
-          if (!isEmailSignup) {
-            return { data: { ...user, emailVerified: true } };
+          await ctx.context.internalAdapter.updateUser(createdAccount.userId, {
+            emailVerified: true,
+          });
+        },
+      },
+    },
+    user: {
+      update: {
+        // Defense-in-depth for the single-email invariant. The /api/account/change-email POST
+        // guard runs at request time; this re-checks when the change is actually applied (the
+        // confirmation-link click is an update op whose ctx carries the session), closing the
+        // race where a social account is linked between request and confirmation.
+        before: async (userData, ctx) => {
+          const changingEmail = typeof userData.email === "string";
+          const userId = ctx?.context.session?.user.id;
+          if (!changingEmail || !userId) return;
+
+          if (await hasLinkedSocialAccount(userId)) {
+            throw new APIError("BAD_REQUEST", {
+              message:
+                "Za promjenu emaila prvo odspoji povezane račune (Google, Facebook).",
+            });
           }
         },
       },
@@ -126,12 +176,9 @@ export const auth = betterAuth({
       enabled: true,
       // Sent to the CURRENT address to approve the change before it applies.
       sendChangeEmailConfirmation: async ({ user, newEmail, url, token }) => {
-        void emailService.sendChangeEmailConfirmation({
-          to: user.email,
-          url,
-          token,
-          newEmail,
-        });
+        void emailService
+          .sendChangeEmailConfirmation({ to: user.email, url, token, newEmail })
+          .catch(logEmailFailure("change-email confirmation"));
       },
     },
   },

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -2,16 +2,12 @@ import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { jwt } from "better-auth/plugins";
 import { nextCookies } from "better-auth/next-js";
+import { and, eq } from "drizzle-orm";
 
 import { db } from "../db";
-
-function requireEnv(name: string): string {
-  const value = process.env[name];
-  if (!value) {
-    throw new Error(`Missing required environment variable: ${name}`);
-  }
-  return value;
-}
+import { account } from "../db/auth-schema";
+import { requireEnv } from "@/lib/env";
+import { emailService } from "@/lib/email";
 
 const BETTER_AUTH_URL = requireEnv("BETTER_AUTH_URL");
 const BETTER_AUTH_SECRET = requireEnv("BETTER_AUTH_SECRET");
@@ -19,6 +15,32 @@ const GOOGLE_CLIENT_ID = requireEnv("NEXT_PUBLIC_GOOGLE_CLIENT_ID");
 const GOOGLE_CLIENT_SECRET = requireEnv("GOOGLE_CLIENT_SECRET");
 const FACEBOOK_CLIENT_ID = requireEnv("FACEBOOK_CLIENT_ID");
 const FACEBOOK_CLIENT_SECRET = requireEnv("FACEBOOK_CLIENT_SECRET");
+
+const RESET_TOKEN_TTL_SECONDS = 60 * 30; // 30 minutes
+
+// The reset flow is reused for two cases that read very differently to the user:
+//   - an OAuth-only account adding a password for the first time  -> "set your password"
+//   - an account that already has a password resetting it          -> "reset your password"
+// We pick the wording by checking whether a credential account already exists, so the same
+// secure token mechanism serves both the forgot-password and register-existing-email flows.
+async function dispatchResetPasswordEmail(
+  userId: string,
+  email: string,
+  url: string,
+  token: string,
+) {
+  const credential = await db
+    .select({ id: account.id })
+    .from(account)
+    .where(and(eq(account.userId, userId), eq(account.providerId, "credential")))
+    .limit(1);
+
+  if (credential.length > 0) {
+    await emailService.sendPasswordReset({ to: email, url, token });
+  } else {
+    await emailService.sendSetPassword({ to: email, url, token });
+  }
+}
 
 export const auth = betterAuth({
   baseURL: BETTER_AUTH_URL,
@@ -35,7 +57,24 @@ export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
     minPasswordLength: 12,
-    // TODO: implement sendResetPassword via Resend for forgot-password flow
+    // Hard gate: email/password login is blocked until the address is verified. OAuth logins
+    // are unaffected (their email is marked verified on creation, see databaseHooks below).
+    requireEmailVerification: true,
+    resetPasswordTokenExpiresIn: RESET_TOKEN_TTL_SECONDS,
+    revokeSessionsOnPasswordReset: true,
+    sendResetPassword: async ({ user, url, token }) => {
+      // Fire-and-forget so the response time is identical whether or not the email exists
+      // (no enumeration oracle). The DB lookup runs inside the un-awaited task.
+      void dispatchResetPasswordEmail(user.id, user.email, url, token);
+    },
+  },
+
+  emailVerification: {
+    sendOnSignUp: true,
+    autoSignInAfterVerification: true,
+    sendVerificationEmail: async ({ user, url, token }) => {
+      void emailService.sendVerificationEmail({ to: user.email, url, token });
+    },
   },
 
   socialProviders: {
@@ -54,18 +93,47 @@ export const auth = betterAuth({
   account: {
     accountLinking: {
       enabled: true,
+      // Auto-link any of these providers that share an email into one account. The link gate
+      // also requires the EXISTING local account to be verified; we satisfy that by marking
+      // OAuth emails verified on creation (databaseHooks below) rather than the deprecated
+      // requireLocalEmailVerified flag.
       trustedProviders: ["google", "facebook"],
-      // TODO: remove requireLocalEmailVerified:false once Resend email verification is wired up
-      // Both flags are required: trustedProviders clears the provider check, this clears the local-email check
-      requireLocalEmailVerified: false,
+    },
+  },
+
+  databaseHooks: {
+    user: {
+      create: {
+        // OAuth providers (Google, Facebook) are trusted to own the email, so mark it verified
+        // on creation. This keeps requireEmailVerification's gate intact for email/password
+        // sign-ups (which must verify) while letting social accounts auto-link and auto-login.
+        // Facebook is the key case: it returns no email-verified claim, so without this it would
+        // be stored unverified and block linking.
+        before: async (user, ctx) => {
+          const isEmailSignup = ctx?.path === "/sign-up/email";
+
+          if (!isEmailSignup) {
+            return { data: { ...user, emailVerified: true } };
+          }
+        },
+      },
     },
   },
 
   user: {
     deleteUser: { enabled: true },
-    // Emails aren't verified yet, so a change applies immediately.
-    // TODO: add sendChangeEmailVerification once Resend email verification is wired up
-    changeEmail: { enabled: true },
+    changeEmail: {
+      enabled: true,
+      // Sent to the CURRENT address to approve the change before it applies.
+      sendChangeEmailConfirmation: async ({ user, newEmail, url, token }) => {
+        void emailService.sendChangeEmailConfirmation({
+          to: user.email,
+          url,
+          token,
+          newEmail,
+        });
+      },
+    },
   },
 
   plugins: [

--- a/frontend/src/lib/email/email-service.ts
+++ b/frontend/src/lib/email/email-service.ts
@@ -1,0 +1,59 @@
+import { EmailProvider } from "./provider";
+import VerificationEmail from "@/emails/verification-email";
+import PasswordResetEmail from "@/emails/password-reset-email";
+import SetPasswordEmail from "@/emails/set-password-email";
+import ChangeEmailConfirmation from "@/emails/change-email-confirmation";
+
+interface TokenEmailArgs {
+  to: string;
+  url: string;
+  // Used to build an idempotency key so a retried hook doesn't send a duplicate.
+  token: string;
+}
+
+interface ChangeEmailArgs extends TokenEmailArgs {
+  newEmail: string;
+}
+
+// Provider-agnostic email use cases. Call sites (Better Auth hooks, the register endpoint)
+// depend on this class, not on Resend — switching providers only touches ./index.
+export class EmailService {
+  constructor(private readonly provider: EmailProvider) {}
+
+  sendVerificationEmail({ to, url, token }: TokenEmailArgs) {
+    return this.provider.send({
+      to,
+      subject: "Potvrdi svoju email adresu",
+      react: VerificationEmail({ verificationUrl: url }),
+      idempotencyKey: `verify-email/${token}`,
+    });
+  }
+
+  sendPasswordReset({ to, url, token }: TokenEmailArgs) {
+    return this.provider.send({
+      to,
+      subject: "Ponovno postavljanje lozinke",
+      react: PasswordResetEmail({ resetUrl: url }),
+      idempotencyKey: `reset-password/${token}`,
+    });
+  }
+
+  // Same underlying reset token, different wording: for OAuth-only accounts adding a password.
+  sendSetPassword({ to, url, token }: TokenEmailArgs) {
+    return this.provider.send({
+      to,
+      subject: "Postavi lozinku za svoj račun",
+      react: SetPasswordEmail({ setPasswordUrl: url }),
+      idempotencyKey: `set-password/${token}`,
+    });
+  }
+
+  sendChangeEmailConfirmation({ to, url, token, newEmail }: ChangeEmailArgs) {
+    return this.provider.send({
+      to,
+      subject: "Potvrdi promjenu email adrese",
+      react: ChangeEmailConfirmation({ confirmUrl: url, newEmail }),
+      idempotencyKey: `change-email/${token}`,
+    });
+  }
+}

--- a/frontend/src/lib/email/index.ts
+++ b/frontend/src/lib/email/index.ts
@@ -1,0 +1,12 @@
+import { requireEnv } from "@/lib/env";
+import { EmailService } from "./email-service";
+import { ResendProvider } from "./resend-provider";
+
+// The only place Resend is wired in. To migrate (e.g. an InfobipProvider implementing
+// EmailProvider), swap this line — EmailService and all templates stay unchanged.
+const provider = new ResendProvider(
+  requireEnv("RESEND_API_KEY"),
+  requireEnv("EMAIL_FROM"),
+);
+
+export const emailService = new EmailService(provider);

--- a/frontend/src/lib/email/index.ts
+++ b/frontend/src/lib/email/index.ts
@@ -1,3 +1,7 @@
+// Build-time guard: importing this module (which reads RESEND_API_KEY) from any client bundle
+// becomes a hard error, so the key can never leak to the browser.
+import "server-only";
+
 import { requireEnv } from "@/lib/env";
 import { EmailService } from "./email-service";
 import { ResendProvider } from "./resend-provider";

--- a/frontend/src/lib/email/provider.ts
+++ b/frontend/src/lib/email/provider.ts
@@ -1,0 +1,20 @@
+import { ReactElement } from "react";
+
+export interface EmailMessage {
+  to: string;
+  subject: string;
+  react: ReactElement;
+  // Dedupes retries of the same logical send; providers that lack support may ignore it.
+  idempotencyKey?: string;
+}
+
+export interface EmailResult {
+  id: string | null;
+  error: string | null;
+}
+
+// Provider-agnostic email transport. The email service and templates depend only on this
+// interface, so swapping the sender (Resend now, Infobip later) touches a single file.
+export interface EmailProvider {
+  send(message: EmailMessage): Promise<EmailResult>;
+}

--- a/frontend/src/lib/email/resend-provider.ts
+++ b/frontend/src/lib/email/resend-provider.ts
@@ -1,0 +1,40 @@
+import { Resend } from "resend";
+
+import { EmailMessage, EmailProvider, EmailResult } from "./provider";
+
+// Resend implementation of EmailProvider. The `from` address must exactly match a verified
+// Resend domain or the API returns 403.
+export class ResendProvider implements EmailProvider {
+  private readonly client: Resend;
+  private readonly from: string;
+
+  constructor(apiKey: string, from: string) {
+    this.client = new Resend(apiKey);
+    this.from = from;
+  }
+
+  async send({
+    to,
+    subject,
+    react,
+    idempotencyKey,
+  }: EmailMessage): Promise<EmailResult> {
+    // The Resend SDK never throws — it returns { data, error }. It renders the React Email
+    // template (and its plain-text alternative) from the `react` field automatically.
+    const { data, error } = await this.client.emails.send(
+      {
+        from: this.from,
+        to: [to],
+        subject,
+        react,
+      },
+      idempotencyKey ? { idempotencyKey } : undefined,
+    );
+
+    if (error) {
+      return { id: null, error: error.message };
+    }
+
+    return { id: data?.id ?? null, error: null };
+  }
+}

--- a/frontend/src/lib/email/resend-provider.ts
+++ b/frontend/src/lib/email/resend-provider.ts
@@ -19,22 +19,31 @@ export class ResendProvider implements EmailProvider {
     react,
     idempotencyKey,
   }: EmailMessage): Promise<EmailResult> {
-    // The Resend SDK never throws — it returns { data, error }. It renders the React Email
-    // template (and its plain-text alternative) from the `react` field automatically.
-    const { data, error } = await this.client.emails.send(
-      {
-        from: this.from,
-        to: [to],
-        subject,
-        react,
-      },
-      idempotencyKey ? { idempotencyKey } : undefined,
-    );
+    try {
+      // The SDK returns { data, error } for API-level errors and renders the React Email
+      // template (plus plain-text) from `react` automatically.
+      const { data, error } = await this.client.emails.send(
+        {
+          from: this.from,
+          to: [to],
+          subject,
+          react,
+        },
+        idempotencyKey ? { idempotencyKey } : undefined,
+      );
 
-    if (error) {
-      return { id: null, error: error.message };
+      if (error) {
+        return { id: null, error: error.message };
+      }
+
+      return { id: data?.id ?? null, error: null };
+    } catch (error) {
+      // It can still THROW on transport/network failures — normalize those into an EmailResult
+      // so fire-and-forget callers never produce an unhandled rejection.
+      return {
+        id: null,
+        error: error instanceof Error ? error.message : "Email transport failed",
+      };
     }
-
-    return { id: data?.id ?? null, error: null };
   }
 }

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -1,0 +1,11 @@
+// Reads a required server env var, throwing at module load if it's missing so a
+// misconfigured deploy fails fast on boot instead of silently at request time.
+export function requireEnv(name: string): string {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return value;
+}


### PR DESCRIPTION
# Disscount — Auth Flow Handoff

A complete description of the authentication system as currently built, why each
decision was made, the problems we hit while building it, and where a fresh
implementation could do better. No file paths — behavior and reasoning only, so
you can re-derive a cleaner implementation in your own way.

Relevant repo skills to use: `better-auth-best-practices`, `email-best-practices`,
`resend`, `react-email`, `frontend-design`. Plus the provided MCPs (context7 for
Better Auth/Resend docs, the Resend MCP for live email/domain/log inspection, and
the Postgres MCP for DB state). Follow `AGENTS.md`.

---

## 1. Architecture (identity vs profile split)

- **Better Auth runs inside the Next.js app** and is the identity provider. It
  owns the `user`, `session`, `account`, `verification`, `jwks` tables in a shared
  Postgres (via Drizzle). It issues **ES256 JWTs** (not the EdDSA default — chosen
  so the Spring resource server validates them via JWKS without extra config).
- **A Spring backend is a pure resource server.** It does not authenticate; it
  validates the JWT via the JWKS endpoint and keeps a slim business **profile**
  row (`app_user`, same UUID PK as the Better Auth user) with username, avatar,
  notification prefs, account type, etc. A provisioning filter lazily upserts the
  profile on the first authenticated request. Username is seeded from the provider
  name; **username is NOT unique, only email is**.
- **Email is a hard invariant.** Both the identity model and business features
  (shared lists, notifications) key off the unique email. A login that can't
  produce an email is rejected.

Implication: identity concerns (passwords, verification, linking, JWT) live in the
Next.js/Better Auth layer; profile concerns live in Spring. Don't blur them.

---

## 2. Email infrastructure

- Transactional email goes through a **provider-agnostic layer**: an
  `EmailProvider` interface, a Resend implementation, and a typed service exposing
  named sends (verification, password reset, change-email). Templates are **React
  Email** components sharing one branded layout. The goal is modularity — swapping
  Resend for Infobip StartUp Tribe later should touch only the provider, not templates
  or call sites.
- All Better Auth email hooks are **fire-and-forget (`void`, not awaited)** to keep
  auth response timing constant (no "does this email exist" timing oracle).
- Gotchas that cost us time:
  - React Email 6 exports everything (components, `render`, `pixelBasedPreset`)
    from the single `react-email` package — not `@react-email/components`.
  - The Resend SDK never throws; it returns `{ data, error }`. The `react:` field
    renders templates automatically.
  - The `from` address must exactly match a **verified** Resend domain. The
    sandbox sender only delivers to your own Resend account email — so "no email
    arrived" during testing is often just the sandbox, not a code bug. Use the
    Resend MCP/logs to confirm what was actually sent.
  - Email creds are read with a `requireEnv` at module load, so the app won't boot
    without them (and the deploy host needs them set).

---

## 3. The flows (all directions + reasons)

### 3.1 Email/password registration — NEW email

1. User submits email + password to a server registration endpoint (not the raw
   Better Auth sign-up, see 3.2 for why).
2. Server detects the email does not exist → performs a normal Better Auth
   sign-up. With `requireEmailVerification` on, this creates the user but **no
   session**, and sends a verification email (`sendOnSignUp`).
3. UI shows a neutral "check your inbox" state (it does not log in).
4. User clicks the verification link → Better Auth verifies and, via
   `autoSignInAfterVerification`, signs them in and redirects into the app.

### 3.2 Registration — email ALREADY has an account (e.g. Google/Facebook)

- **Why a custom endpoint exists:** Better Auth's `signUp.email` is
  anti-enumeration — for an existing email it returns a phantom `200` (no row, no
  email). So the client cannot tell "new" from "exists", and you cannot link a
  password to an existing account through sign-up (deliberate account-takeover
  protection).
- The server endpoint therefore branches on existence (one internal lookup) and,
  for an existing account, triggers the **password-reset / "set your password"
  flow** instead. Better Auth's own docs state that the forgot-password flow links
  a credential account for password-less (OAuth-only) users — so this is the
  supported way to add email/password to a social account.
- Both branches return the **same response** ("check your inbox"), so account
  existence never leaks.
- Net effect: confirming the emailed link results in the user having all login
  methods that apply (email/password plus whatever socials were linked).

### 3.3 Email verification (hard gate)

- `requireEmailVerification` is ON. Email/password login is blocked until verified;
  OAuth users are unaffected (their email is verified by the provider — except
  Facebook, see 3.8). Unverified login attempts re-send the verification email.

### 3.4 Email/password login

- Standard. On a `403` (email not verified) the UI shows a "check your inbox, we
  re-sent the link" message rather than a generic error.

### 3.5 Forgot password / set password

- A forgot-password form requests a reset; the reset link opens a **reset modal**
  (rendered on a route but styled like the auth dialogs). Setting the password
  creates the credential if the user had none (OAuth-only), which is exactly how
  3.2 reuses it.

### 3.6 Auto-login after setting a password

- After a successful reset/set-password the app **signs the user in automatically**
  with the new password and redirects home, instead of telling them to log in.
- The email is carried to the reset page via the reset `redirectTo` (so the page
  can sign in). If auto-login is blocked (see 3.8) it falls back to a "now you can
  log in" toast.

### 3.7 Google sign-in

- Standard OAuth. Google returns a verified email → `email_verified=true`. Profile
  (username, avatar) flows from the JWT into the Spring profile on first request.

### 3.8 Facebook sign-in

- Email is required: request the `email` scope, and if Facebook returns none, the
  login is **rejected gracefully** (a toast), never creating a profile-less user.
- Important quirk: **Facebook accounts are stored with `email_verified=false`**
  (Facebook doesn't return a verified claim). This ripples into linking (3.9) and
  auto-login (3.6).

### 3.9 Account auto-linking on sign-in

- Goal: signing in with any provider that shares an email links into the one
  account. Configured via `trustedProviders` + `requireLocalEmailVerified:false`.
- **The trap (cost us a lot of time):** Better Auth's link gate (source:
  `link-account.ts`, v1.6.11+) blocks auto-linking when the _existing_ account is
  unverified unless `requireLocalEmailVerified` is false. Because Facebook accounts
  are unverified, Google-signing-into-a-Facebook-account silently failed
  (`account_not_linked`) until that flag was set. `trustedProviders` alone is not
  enough. Note this flag is **deprecated** — see recommendations.

### 3.10 Manual linking in settings + mismatched email

- Security settings let a logged-in user link the other social provider or set a
  password. Linking an account whose email differs from the logged-in user's
  triggers `email_doesn't_match` (linking-only protection). We surface this nicely
  via an `errorCallbackURL` that returns into the app + a toast.

### 3.11 Change email

- Enabled with a confirmation sent to the current address before the change
  applies. The correct Better Auth option is `sendChangeEmailConfirmation` (not
  `...Verification`).

---

## 4. Cross-cutting traps (read before changing anything)

1. **Better Auth `auth` is a module singleton.** Next.js HMR does NOT recreate it
   when the auth config file changes. Symptoms we chased for ages: "verification
   email not sent", "linking not working" — all were **stale config until a
   dev-server restart**. Always restart after auth-config edits. Consider
   documenting this prominently or finding a dev workaround.
2. **OAuth error params get stripped during session load.** The failed-OAuth
   redirect lands with `?error=...`, but reading `window.location` lost a race
   against a URL rewrite that happens around the session fetch. Reading the param
   from the router snapshot (Next's `useSearchParams`) is robust; raw
   `window.location` is not.
3. **The OAuth-error toast must be globally mounted.** It originally lived inside
   the login/auth modal, which logged-in users don't render — so account-linking
   errors (which happen while logged in) never showed. Mount it app-wide.
4. **Anti-enumeration everywhere.** Sign-up and password-reset both return
   identical responses regardless of whether the email exists. Don't add UI hints
   like "you may already have an account" — that re-introduces enumeration.
5. **`email_verified` differs by provider** (Google true, Facebook false). Any
   logic gated on local-email-verified must account for Facebook.
6. **Typos in Better Auth option names fail silently at runtime** (unknown keys are
   ignored). TypeScript catches some (e.g. an implicit-any on the callback args
   revealed `sendChangeEmailVerification` should be `sendChangeEmailConfirmation`).
   Lean on `tsc`.

---

## 5. Known issues / things to reconsider (recommendations)

- **`requireLocalEmailVerified:false` is deprecated.** Cleaner and future-proof:
  mark OAuth emails verified on user creation (a `databaseHooks.user.create` hook),
  so the security gate can stay ON and auto-linking still works. This also makes
  Facebook auto-login after set-password (3.6) work without the fallback.
- **The "register existing account → reset email" UX** reuses the password-reset
  copy ("reset your password"), which reads oddly for a first-time set. Consider a
  dedicated email/template and clearer wording, or a unified "finish setting up
  your account" flow. (We built a heavier custom encrypted-token flow that honored
  the typed password through to confirmation, then scrapped it as too much code in
  favor of the reset-flow reuse. A fresh design might find a cleaner middle ground.)
- **Auto-login passes the email via the URL** to the reset page. Verify Better Auth
  appends `&token=` correctly when `redirectTo` already has a query, and consider
  whether `resetPassword` should also mark the email verified (it would make
  Facebook accounts auto-login).
- **Hard `requireEmailVerification`** locks out any pre-existing unverified
  email/password users until they verify. Decide if a soft/transition mode is
  needed.
- **Reset screen is a modal rendered on a route**, and the OAuth-error handling is
  a global toast component — both pragmatic. A cleaner, unified "auth feedback"
  abstraction may be possible.
- **Email deliverability** is unaddressed beyond domain verification: set
  SPF/DKIM/DMARC, consider dedicated sending subdomains, and add one-click
  unsubscribe before any marketing email. Templates are HR-only (no i18n yet).
- **USKORO placeholders** (novosti newsletter, watchlist-discount alerts, feedback
  contact) are disabled UI stubs. The discount alerts in particular need a
  server-side price-check job in Spring (discount detection is currently
  client-only) plus backend preference fields; the newsletter needs Resend
  Broadcasts/Topics. Keep the DB the source of truth for prefs (for Infobip
  portability), not Resend.
- **Modularity is in place** for the email provider; preserve it. Don't couple
  preference logic to Resend.
- **Two pre-existing `react-hooks/set-state-in-effect` ESLint errors** exist
  (unrelated to this work) — worth cleaning up separately.

---

## 6. Suggested validation for any reimplementation

- Use the Postgres MCP to inspect `user.email_verified` and the `account` rows
  (per provider) after each flow — it's the fastest way to see what actually
  happened.
- Use the Resend MCP (`list-emails`, `list-logs`) to confirm what was really sent
  vs. what the UI claimed.
- Test the matrix: new email signup; signup with an email that already has Google;
  signup with an email that already has Facebook; forgot-password for an
  email/password user; forgot-password for an OAuth-only user; Google-into-Facebook
  auto-link; linking a mismatched email; change email. Restart the dev server
  between auth-config changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password reset, email verification, and email-change flows.
  * Introduced inbox and toast feedback for account and OAuth actions.
  * Added transactional emails for verification, reset, password setup, and email-change confirmation.

* **Bug Fixes**
  * Improved sign-in and registration handling to avoid account-enumeration issues.
  * Prevented email changes when linked social accounts could cause login mismatches.
  * Added clearer validation and error messages for login, registration, and password reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->