### PR TITLE
feat: Unify products card and watchlist item into a shared ProductCard

### DIFF
--- a/frontend/src/app/(root)/components/sections/logo-row.tsx
+++ b/frontend/src/app/(root)/components/sections/logo-row.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import StoreChainLogo from "@/components/custom/store-chain/store-chain-logo";
+import { storeNamesMap } from "@/constants/name-mappings";
+import { getChainLabel } from "@/utils/labels";
+
+const chains = Object.keys(storeNamesMap);
+
+interface ILogoRowProps {
+  ariaHidden?: boolean;
+}
+
+export default function LogoRow({ ariaHidden = false }: ILogoRowProps) {
+  return (
+    <ul
+      aria-hidden={ariaHidden || undefined}
+      className="flex shrink-0 items-center gap-2 sm:gap-6 pr-2 sm:pr-6"
+    >
+      {chains.map((chain) => (
+        <li key={chain} className="shrink-0">
+          <Link
+            href={`/products?chain=${chain}`}
+            aria-label={`Pogledaj cijene - ${getChainLabel(chain)}`}
+            tabIndex={ariaHidden ? -1 : undefined}
+            className="grid size-20 sm:size-24 cursor-pointer place-items-center rounded-2xl border bg-white p-1.5 shadow-sm transition-transform hover:scale-105"
+          >
+            <StoreChainLogo
+              chain={chain}
+              className="object-contain rounded-md"
+            />
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/app/(root)/components/sections/price-history-section.tsx
+++ b/frontend/src/app/(root)/components/sections/price-history-section.tsx
@@ -48,7 +48,7 @@ export default function PriceHistorySection() {
           </Button>
         </div>
 
-        <div className="relative bg-card border rounded-3xl p-8 shadow-sm">
+        <div className="relative bg-card border rounded-3xl p-8 shadow-sm hidden sm:block">
           <PriceLineDoodle className="w-full h-auto text-primary" />
           <p className="mt-4 text-center text-xs uppercase tracking-wider text-muted-foreground text-pretty">
             Cijena kroz vrijeme

--- a/frontend/src/app/(root)/components/sections/pricing-receipt.tsx
+++ b/frontend/src/app/(root)/components/sections/pricing-receipt.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import EdgeFade from "@/components/custom/common/edge-fade";
+import ReceiptRow from "@/app/(root)/components/sections/receipt-row";
 import type { IPricingRow } from "@/app/(root)/data/landing";
 
 interface IPricingReceiptProps {
@@ -16,21 +17,6 @@ interface IPricingReceiptProps {
 // Free and premium render identically, differing only in copy, badge and dimming.
 const receiptClip =
   "[clip-path:polygon(0_0,100%_0,100%_calc(100%-8px),97%_100%,94%_calc(100%-8px),91%_100%,88%_calc(100%-8px),85%_100%,82%_calc(100%-8px),79%_100%,76%_calc(100%-8px),73%_100%,70%_calc(100%-8px),67%_100%,64%_calc(100%-8px),61%_100%,58%_calc(100%-8px),55%_100%,52%_calc(100%-8px),49%_100%,46%_calc(100%-8px),43%_100%,40%_calc(100%-8px),37%_100%,34%_calc(100%-8px),31%_100%,28%_calc(100%-8px),25%_100%,22%_calc(100%-8px),19%_100%,16%_calc(100%-8px),13%_100%,10%_calc(100%-8px),7%_100%,4%_calc(100%-8px),1%_100%,0_calc(100%-8px))]";
-
-interface IReceiptRowProps {
-  label: string;
-  price: string;
-}
-
-function ReceiptRow({ label, price }: IReceiptRowProps) {
-  return (
-    <li className="flex items-baseline gap-2 text-sm">
-      <span className="text-pretty">{label}</span>
-      <span className="flex-1 border-b border-dotted border-muted-foreground/40" />
-      <span className="font-mono text-pretty">{price}</span>
-    </li>
-  );
-}
 
 export default function PricingReceipt({
   name,

--- a/frontend/src/app/(root)/components/sections/receipt-row.tsx
+++ b/frontend/src/app/(root)/components/sections/receipt-row.tsx
@@ -1,0 +1,14 @@
+interface IReceiptRowProps {
+  label: string;
+  price: string;
+}
+
+export default function ReceiptRow({ label, price }: IReceiptRowProps) {
+  return (
+    <li className="flex items-baseline gap-2 text-sm">
+      <span className="text-pretty">{label}</span>
+      <span className="flex-1 border-b border-dotted border-muted-foreground/40" />
+      <span className="font-mono text-pretty">{price}</span>
+    </li>
+  );
+}

--- a/frontend/src/app/(root)/components/sections/stats-band.tsx
+++ b/frontend/src/app/(root)/components/sections/stats-band.tsx
@@ -13,7 +13,7 @@ export default function StatsBand() {
     <section className="relative">
       <h2 className="sr-only">Disscount u brojkama</h2>
 
-      <div className="relative overflow-hidden rounded-3xl bg-primary text-primary-foreground px-6 py-10 sm:py-12 shadow-lg">
+      <div className="relative overflow-hidden rounded-3xl bg-primary text-primary-foreground px-6 py-4 sm:py-8 shadow-lg">
         <SparkleField
           count={6}
           seed="stats-sparkles"
@@ -26,7 +26,7 @@ export default function StatsBand() {
           className="grid grid-cols-1 sm:grid-cols-3 text-center divide-y-2 divide-dashed divide-primary-foreground/40 sm:divide-y-0 sm:divide-x-2"
         >
           {statItems.map((stat) => (
-            <div key={stat.label} className="space-y-1 py-7 sm:px-6">
+            <div key={stat.label} className="space-y-1 py-4 sm:px-6">
               <div className="text-4xl sm:text-5xl font-saira-stencil-semibold text-pretty">
                 {stat.value}
               </div>

--- a/frontend/src/app/(root)/components/sections/stores-marquee.tsx
+++ b/frontend/src/app/(root)/components/sections/stores-marquee.tsx
@@ -1,41 +1,5 @@
-import Link from "next/link";
-import StoreChainLogo from "@/components/custom/store-chain/store-chain-logo";
-import { storeNamesMap } from "@/constants/name-mappings";
-import { getChainLabel } from "@/utils/labels";
+import LogoRow from "@/app/(root)/components/sections/logo-row";
 
-const chains = Object.keys(storeNamesMap);
-
-interface ILogoRowProps {
-  ariaHidden?: boolean;
-}
-
-function LogoRow({ ariaHidden = false }: ILogoRowProps) {
-  return (
-    <ul
-      aria-hidden={ariaHidden || undefined}
-      className="flex shrink-0 items-center gap-4 pr-4"
-    >
-      {chains.map((chain) => (
-        <li key={chain} className="shrink-0">
-          <Link
-            href={`/products?chain=${chain}`}
-            aria-label={`Pogledaj cijene - ${getChainLabel(chain)}`}
-            tabIndex={ariaHidden ? -1 : undefined}
-            className="grid size-16 sm:size-20 cursor-pointer place-items-center rounded-2xl border bg-white p-2.5 shadow-sm transition-transform hover:scale-105"
-          >
-            <StoreChainLogo
-              chain={chain}
-              className="object-contain rounded-lg"
-            />
-          </Link>
-        </li>
-      ))}
-    </ul>
-  );
-}
-
-// Two identical rows sliding by -50% make the CSS loop seamless; it pauses on
-// hover and stops under prefers-reduced-motion, both defined in globals.css.
 export default function StoresMarquee() {
   return (
     <div className="group/marquee relative overflow-x-clip">

--- a/frontend/src/app/(root)/data/landing.ts
+++ b/frontend/src/app/(root)/data/landing.ts
@@ -57,7 +57,7 @@ export const freePlanRows: IPricingRow[] = [
   { label: "Praćenje proizvoda" },
   { label: "Obavijesti o padu cijena" },
   { label: "Skeniranje barkoda" },
-  { label: "Instalacija kao aplikacija (PWA)" },
+  { label: "Instalacija kao aplikacija" },
 ];
 
 export const proPlanRows: IPricingRow[] = [

--- a/frontend/src/app/(user)/digital-cards/components/forms/digital-card-fields.tsx
+++ b/frontend/src/app/(user)/digital-cards/components/forms/digital-card-fields.tsx
@@ -12,13 +12,7 @@ import {
   FormMessage,
   FormDescription,
 } from "@/components/ui/form";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import DigitalCardSelectField from "@/app/(user)/digital-cards/components/forms/digital-card-select-field";
 import type { DigitalCardRequest } from "@/lib/api/types";
 
 const CARD_TYPES = [
@@ -35,44 +29,6 @@ const CODE_TYPES = [
   { value: "number", label: "Broj" },
   { value: "text", label: "Tekst" },
 ];
-
-interface ISelectFieldProps {
-  name: "type" | "codeType";
-  label: string;
-  placeholder: string;
-  options: { value: string; label: string }[];
-}
-
-function SelectField({ name, label, placeholder, options }: ISelectFieldProps) {
-  const form = useFormContext<DigitalCardRequest>();
-
-  return (
-    <FormField
-      control={form.control}
-      name={name}
-      render={({ field }) => (
-        <FormItem>
-          <FormLabel>{label}</FormLabel>
-          <Select onValueChange={field.onChange} value={field.value}>
-            <FormControl>
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder={placeholder} />
-              </SelectTrigger>
-            </FormControl>
-            <SelectContent>
-              {options.map((option) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <FormMessage />
-        </FormItem>
-      )}
-    />
-  );
-}
 
 export default function DigitalCardFields() {
   const form = useFormContext<DigitalCardRequest>();
@@ -107,14 +63,14 @@ export default function DigitalCardFields() {
         )}
       />
 
-      <SelectField
+      <DigitalCardSelectField
         name="type"
         label="Tip kartice"
         placeholder="Odaberi tip"
         options={CARD_TYPES}
       />
 
-      <SelectField
+      <DigitalCardSelectField
         name="codeType"
         label="Tip koda"
         placeholder="Odaberi tip koda"

--- a/frontend/src/app/(user)/digital-cards/components/forms/digital-card-select-field.tsx
+++ b/frontend/src/app/(user)/digital-cards/components/forms/digital-card-select-field.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useFormContext } from "react-hook-form";
+
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { DigitalCardRequest } from "@/lib/api/types";
+
+interface IDigitalCardSelectFieldProps {
+  name: "type" | "codeType";
+  label: string;
+  placeholder: string;
+  options: { value: string; label: string }[];
+}
+
+export default function DigitalCardSelectField({
+  name,
+  label,
+  placeholder,
+  options,
+}: IDigitalCardSelectFieldProps) {
+  const form = useFormContext<DigitalCardRequest>();
+
+  return (
+    <FormField
+      control={form.control}
+      name={name}
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>{label}</FormLabel>
+          <Select onValueChange={field.onChange} value={field.value}>
+            <FormControl>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder={placeholder} />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              {options.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}

--- a/frontend/src/app/(user)/watchlist/components/watchlist-discount-row.tsx
+++ b/frontend/src/app/(user)/watchlist/components/watchlist-discount-row.tsx
@@ -10,6 +10,7 @@ interface IWatchlistDiscountRowProps {
   text: string;
   stores: INotificationStore[];
   bold?: boolean;
+  tooltipSide?: "top" | "right" | "bottom" | "left";
 }
 
 export default function WatchlistDiscountRow({
@@ -18,6 +19,7 @@ export default function WatchlistDiscountRow({
   text,
   stores,
   bold = false,
+  tooltipSide,
 }: IWatchlistDiscountRowProps) {
   const color = cn({
     "text-red-700": (difference ?? 0) > 0,
@@ -29,7 +31,7 @@ export default function WatchlistDiscountRow({
     <div className="flex items-center justify-start gap-2">
       <Icon className={cn("size-4 sm:size-5", color)} />
 
-      <StorePriceTooltip stores={stores}>
+      <StorePriceTooltip stores={stores} side={tooltipSide}>
         <p className={cn("text-sm", bold ? "font-bold" : "font-medium", color)}>
           {text}
         </p>

--- a/frontend/src/app/(user)/watchlist/components/watchlist-discount-row.tsx
+++ b/frontend/src/app/(user)/watchlist/components/watchlist-discount-row.tsx
@@ -1,0 +1,39 @@
+import { LucideIcon } from "lucide-react";
+
+import StorePriceTooltip from "@/components/custom/price/store-price-tooltip";
+import { cn } from "@/lib/utils";
+import type { INotificationStore } from "@/context/notifications-types";
+
+interface IWatchlistDiscountRowProps {
+  icon: LucideIcon;
+  difference: number | null;
+  text: string;
+  stores: INotificationStore[];
+  bold?: boolean;
+}
+
+export default function WatchlistDiscountRow({
+  icon: Icon,
+  difference,
+  text,
+  stores,
+  bold = false,
+}: IWatchlistDiscountRowProps) {
+  const color = cn({
+    "text-red-700": (difference ?? 0) > 0,
+    "text-green-700": (difference ?? 0) < 0,
+    "text-gray-700": (difference ?? 0) === 0,
+  });
+
+  return (
+    <div className="flex items-center justify-start gap-2">
+      <Icon className={cn("size-4 sm:size-5", color)} />
+
+      <StorePriceTooltip stores={stores}>
+        <p className={cn("text-sm", bold ? "font-bold" : "font-medium", color)}>
+          {text}
+        </p>
+      </StorePriceTooltip>
+    </div>
+  );
+}

--- a/frontend/src/app/(user)/watchlist/components/watchlist-discount-row.tsx
+++ b/frontend/src/app/(user)/watchlist/components/watchlist-discount-row.tsx
@@ -2,6 +2,7 @@ import { LucideIcon } from "lucide-react";
 
 import StorePriceTooltip from "@/components/custom/price/store-price-tooltip";
 import { cn } from "@/lib/utils";
+import { priceDeltaColorClass } from "@/utils/price";
 import type { INotificationStore } from "@/context/notifications-types";
 
 interface IWatchlistDiscountRowProps {
@@ -21,18 +22,17 @@ export default function WatchlistDiscountRow({
   bold = false,
   tooltipSide,
 }: IWatchlistDiscountRowProps) {
-  const color = cn({
-    "text-red-700": (difference ?? 0) > 0,
-    "text-green-700": (difference ?? 0) < 0,
-    "text-gray-700": (difference ?? 0) === 0,
-  });
+  const color = priceDeltaColorClass(difference);
 
   return (
     <div className="flex items-center justify-start gap-2">
       <Icon className={cn("size-4 sm:size-5", color)} />
 
       <StorePriceTooltip stores={stores} side={tooltipSide}>
-        <p className={cn("text-sm", bold ? "font-bold" : "font-medium", color)}>
+        <p
+          tabIndex={0}
+          className={cn("text-sm", bold ? "font-bold" : "font-medium", color)}
+        >
           {text}
         </p>
       </StorePriceTooltip>

--- a/frontend/src/app/(user)/watchlist/components/watchlist-item-discount-info.tsx
+++ b/frontend/src/app/(user)/watchlist/components/watchlist-item-discount-info.tsx
@@ -4,20 +4,15 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Separator } from "@/components/ui/separator";
 import { openModalUrl } from "@/lib/modal/modal-navigation";
 import WatchlistDiscountRow from "@/app/(user)/watchlist/components/watchlist-discount-row";
-import {
-  formatDifference,
-  toStoreLines,
-} from "@/app/(user)/watchlist/utils/discount-display-utils";
-import {
-  IDiscountInfo,
-  IScopedDiscountedStore,
-} from "@/app/(user)/watchlist/utils/watchlist-utils";
+import { formatDifference } from "@/app/(user)/watchlist/utils/discount-display-utils";
+import { IDiscountInfo } from "@/app/(user)/watchlist/utils/watchlist-utils";
+import type { INotificationStore } from "@/context/notifications-types";
 
 interface IWatchlistItemDiscountInfoProps {
   discountInfo: IDiscountInfo | null;
   hasPinnedStores: boolean;
-  preferredStores: IScopedDiscountedStore[];
-  totalStores: IScopedDiscountedStore[];
+  preferredStores: INotificationStore[];
+  totalStores: INotificationStore[];
   isLoading: boolean;
   error: Error | null;
 }
@@ -59,7 +54,7 @@ export default function WatchlistItemDiscountInfo({
             discountInfo.preferredPercentage,
             "Nedostupno",
           )}
-          stores={toStoreLines(preferredStores)}
+          stores={preferredStores}
           bold
         />
       ) : (
@@ -88,7 +83,8 @@ export default function WatchlistItemDiscountInfo({
           discountInfo.totalPercentage,
           "Nema podataka",
         )}
-        stores={toStoreLines(totalStores)}
+        stores={totalStores}
+        tooltipSide="bottom"
       />
     </div>
   );

--- a/frontend/src/app/(user)/watchlist/components/watchlist-item-discount-info.tsx
+++ b/frontend/src/app/(user)/watchlist/components/watchlist-item-discount-info.tsx
@@ -1,13 +1,23 @@
 import { Star, Store } from "lucide-react";
+
 import { Skeleton } from "@/components/ui/skeleton";
 import { Separator } from "@/components/ui/separator";
-import { IDiscountInfo } from "@/app/(user)/watchlist/utils/watchlist-utils";
-import { cn } from "@/lib/utils";
 import { openModalUrl } from "@/lib/modal/modal-navigation";
+import WatchlistDiscountRow from "@/app/(user)/watchlist/components/watchlist-discount-row";
+import {
+  formatDifference,
+  toStoreLines,
+} from "@/app/(user)/watchlist/utils/discount-display-utils";
+import {
+  IDiscountInfo,
+  IScopedDiscountedStore,
+} from "@/app/(user)/watchlist/utils/watchlist-utils";
 
 interface IWatchlistItemDiscountInfoProps {
   discountInfo: IDiscountInfo | null;
   hasPinnedStores: boolean;
+  preferredStores: IScopedDiscountedStore[];
+  totalStores: IScopedDiscountedStore[];
   isLoading: boolean;
   error: Error | null;
 }
@@ -15,6 +25,8 @@ interface IWatchlistItemDiscountInfoProps {
 export default function WatchlistItemDiscountInfo({
   discountInfo,
   hasPinnedStores,
+  preferredStores,
+  totalStores,
   isLoading,
   error,
 }: IWatchlistItemDiscountInfoProps) {
@@ -22,7 +34,7 @@ export default function WatchlistItemDiscountInfo({
     return (
       <div className="space-y-2">
         <Skeleton className="h-4 w-24 ml-auto" />
-        <Separator className="" />
+        <Separator />
         <Skeleton className="h-4 w-20 ml-auto" />
       </div>
     );
@@ -37,71 +49,47 @@ export default function WatchlistItemDiscountInfo({
   }
 
   return (
-    <>
-      <div className="flex flex-col gap-2">
-        <div className="flex items-center justify-start gap-2">
-          <Star
-            className={cn("size-4 sm:size-5", {
-              "text-red-700": (discountInfo.preferredDifference ?? 0) > 0,
-              "text-green-700": (discountInfo.preferredDifference ?? 0) < 0,
-              "text-gray-700": (discountInfo.preferredDifference ?? 0) === 0,
-            })}
-          />
-
-          {hasPinnedStores ? (
-            <p
-              className={cn("text-sm font-bold", {
-                "text-red-700": (discountInfo.preferredDifference ?? 0) > 0,
-                "text-green-700": (discountInfo.preferredDifference ?? 0) < 0,
-                "text-gray-700": (discountInfo.preferredDifference ?? 0) === 0,
-              })}
-            >
-              {discountInfo.preferredDifference !== null &&
-              discountInfo.preferredPercentage !== null
-                ? `${discountInfo.preferredDifference > 0 ? "+" : ""}${discountInfo.preferredDifference.toFixed(2)}€ (${Math.round(Math.abs(discountInfo.preferredPercentage))}%)`
-                : "Nedostupno"}
-            </p>
-          ) : (
-            <button
-              type="button"
-              className="text-xs text-muted-foreground hover:text-primary transition-colors cursor-pointer italic"
-              onClick={() =>
-                openModalUrl({ name: "settings", tab: "preference" })
-              }
-            >
-              Postavi preference
-            </button>
+    <div className="flex flex-col gap-2">
+      {hasPinnedStores ? (
+        <WatchlistDiscountRow
+          icon={Star}
+          difference={discountInfo.preferredDifference}
+          text={formatDifference(
+            discountInfo.preferredDifference,
+            discountInfo.preferredPercentage,
+            "Nedostupno",
           )}
-        </div>
-
-        <Separator className="" />
-
+          stores={toStoreLines(preferredStores)}
+          bold
+        />
+      ) : (
         <div className="flex items-center justify-start gap-2">
-          <Store
-            className={cn("size-4 sm:size-5", {
-              "text-red-700": (discountInfo.totalDifference ?? 0) > 0,
-              "text-green-700": (discountInfo.totalDifference ?? 0) < 0,
-              "text-gray-700": (discountInfo.totalDifference ?? 0) === 0,
-            })}
-          />
+          <Star className="size-4 sm:size-5 text-gray-700" />
 
-          <p
-            className={cn(
-              "text-sm font-medium text-right flex gap-2 flex-wrap items-center justify-end transition-all",
-              {
-                "text-red-700": (discountInfo.totalDifference ?? 0) > 0,
-                "text-green-700": (discountInfo.totalDifference ?? 0) < 0,
-                "text-gray-700": (discountInfo.totalDifference ?? 0) === 0,
-              },
-            )}
+          <button
+            type="button"
+            className="text-xs text-muted-foreground hover:text-primary transition-colors cursor-pointer italic"
+            onClick={() =>
+              openModalUrl({ name: "settings", tab: "preference" })
+            }
           >
-            {discountInfo.totalDifference !== null &&
-            discountInfo.totalPercentage !== null
-              ? `${discountInfo.totalDifference > 0 ? "+" : ""}${discountInfo.totalDifference.toFixed(2)}€ (${Math.round(Math.abs(discountInfo.totalPercentage))}%)`
-              : "Nema podataka"}
-          </p>
+            Postavi preference
+          </button>
         </div>
-      </div>
-    </>
+      )}
+
+      <Separator />
+
+      <WatchlistDiscountRow
+        icon={Store}
+        difference={discountInfo.totalDifference}
+        text={formatDifference(
+          discountInfo.totalDifference,
+          discountInfo.totalPercentage,
+          "Nema podataka",
+        )}
+        stores={toStoreLines(totalStores)}
+      />
+    </div>
   );
 }

--- a/frontend/src/app/(user)/watchlist/components/watchlist-item.tsx
+++ b/frontend/src/app/(user)/watchlist/components/watchlist-item.tsx
@@ -54,6 +54,7 @@ export default function WatchlistItem({
       quantity={quantityWithUnit}
       isLoading={isLoading}
       onClick={() => navigateToProduct(productApiId, product)}
+      trailingWraps
       trailing={
         <>
           <WatchlistItemDiscountInfo

--- a/frontend/src/app/(user)/watchlist/components/watchlist-item.tsx
+++ b/frontend/src/app/(user)/watchlist/components/watchlist-item.tsx
@@ -1,15 +1,12 @@
 "use client";
 
-import Link from "next/link";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Skeleton } from "@/components/ui/skeleton";
 import { IWatchlistItemWithProduct } from "@/app/(user)/watchlist/utils/watchlist-utils";
-import { cn } from "@/lib/utils";
+import { useWatchlistItem } from "@/app/(user)/watchlist/hooks/use-watchlist-item";
 import WatchlistItemDiscountInfo from "@/app/(user)/watchlist/components/watchlist-item-discount-info";
 import WatchlistActionButton from "@/app/(user)/watchlist/components/watchlist-action-button";
-import { useWatchlistItem } from "@/app/(user)/watchlist/hooks/use-watchlist-item";
-import { WatchType } from "@/lib/api";
+import WatchlistThresholdBadges from "@/app/(user)/watchlist/components/watchlist-threshold-badges";
+import ProductCard from "@/components/custom/product/product-card";
+import useProductNavigation from "@/hooks/use-product-navigation";
 
 interface IWatchlistItemProps {
   item: IWatchlistItemWithProduct;
@@ -38,116 +35,57 @@ export default function WatchlistItem({
     productName,
     productBrand,
     quantityWithUnit,
+    category,
     hasPinnedStores,
+    preferredStores,
+    totalStores,
     isWatchRequirementAchieved,
     handleBadgeClick,
     handleOpenWatchlistModal,
   } = useWatchlistItem(item);
 
+  const navigateToProduct = useProductNavigation();
+
   return (
-    <Card className="hover:shadow-md transition-shadow">
-      <CardContent className="p-4">
-        {/* First row: Product name, brand, and remove button */}
-        <div className="flex  justify-between gap-4 sm:flex-row flex-col">
-          <div className="flex items-center justify-between gap-4">
-            {/* Product info - clickable */}
-            <Link href={`/products/${productApiId}`}>
-              <div className="space-y-2 w-fit">
-                {isLoading ? (
-                  <>
-                    <Skeleton className="h-5 w-48" />
-                    <Skeleton className="h-4 w-32" />
-                  </>
-                ) : (
-                  <>
-                    <h4 className="text-sm sm:text-md hover:text-primary transition-colors">
-                      {productName}
-                      {quantityWithUnit ? ` (${quantityWithUnit})` : ""}
-                    </h4>
-                    {productBrand && (
-                      <p className="text-xs sm:text-sm text-gray-600">
-                        {productBrand}
-                      </p>
-                    )}
-                  </>
-                )}
-              </div>
-            </Link>
+    <ProductCard
+      name={productName}
+      brand={productBrand}
+      category={category}
+      quantity={quantityWithUnit}
+      isLoading={isLoading}
+      onClick={() => navigateToProduct(productApiId, product)}
+      trailing={
+        <>
+          <WatchlistItemDiscountInfo
+            discountInfo={discountInfo}
+            hasPinnedStores={hasPinnedStores}
+            preferredStores={preferredStores}
+            totalStores={totalStores}
+            isLoading={isLoading}
+            error={error}
+          />
 
+          <div className="flex flex-col items-center gap-2">
             <WatchlistActionButton
-              visibilityClassName="sm:hidden size-8 sm:size-10 shrink-0"
+              visibilityClassName="size-8 sm:size-10 shrink-0"
               isAddMode={isAddMode}
               isRemoving={isRemoving}
               hasProduct={Boolean(product)}
               onAdd={handleOpenWatchlistModal}
               onRemove={handleRemove}
             />
-          </div>
 
-          <div className="flex items-center gap-4">
-            <div className="flex items-center justify-between gap-4 w-full">
-              {/* Discount info */}
-              <WatchlistItemDiscountInfo
-                discountInfo={discountInfo}
-                hasPinnedStores={hasPinnedStores}
-                isLoading={isLoading}
-                error={error}
+            {showThresholdBadges && (
+              <WatchlistThresholdBadges
+                items={watchlistItems}
+                disabled={!product}
+                isAchieved={isWatchRequirementAchieved}
+                onEdit={handleBadgeClick}
               />
-
-              {/* Threshold badges */}
-              {showThresholdBadges && (
-                <div className="flex flex-col items-center justify-center gap-2">
-                  {[...watchlistItems]
-                    .sort((a, b) =>
-                      a.watchType === WatchType.percentage
-                        ? -1
-                        : b.watchType === WatchType.percentage
-                          ? 1
-                          : 0,
-                    )
-                    .map((watchlistItem) => (
-                      <Badge
-                        key={watchlistItem.id}
-                        variant="outline"
-                        asChild
-                        className={cn(
-                          "text-xs cursor-pointer",
-                          isWatchRequirementAchieved(
-                            watchlistItem.thresholdValue,
-                            watchlistItem.watchType,
-                          ) &&
-                            "border-green-600 bg-green-50 text-green-700 font-bold",
-                        )}
-                      >
-                        <button
-                          type="button"
-                          onClick={(event) =>
-                            handleBadgeClick(event, watchlistItem.watchType)
-                          }
-                          disabled={!product}
-                        >
-                          {watchlistItem.watchType === "ABSOLUTE"
-                            ? `- ${watchlistItem.thresholdValue.toFixed(2)}€`
-                            : `- ${Math.round(watchlistItem.thresholdValue)}%`}
-                        </button>
-                      </Badge>
-                    ))}
-                </div>
-              )}
-            </div>
-
-            {/* Remove button - hidden on mobile, shown on larger screens */}
-            <WatchlistActionButton
-              visibilityClassName="hidden sm:flex size-8 sm:size-10 shrink-0"
-              isAddMode={isAddMode}
-              isRemoving={isRemoving}
-              hasProduct={Boolean(product)}
-              onAdd={handleOpenWatchlistModal}
-              onRemove={handleRemove}
-            />
+            )}
           </div>
-        </div>
-      </CardContent>
-    </Card>
+        </>
+      }
+    />
   );
 }

--- a/frontend/src/app/(user)/watchlist/components/watchlist-item.tsx
+++ b/frontend/src/app/(user)/watchlist/components/watchlist-item.tsx
@@ -66,7 +66,7 @@ export default function WatchlistItem({
             error={error}
           />
 
-          <div className="flex flex-col items-center gap-2">
+          <div className="flex flex-col items-center gap-2 sm:flex-row-reverse">
             <WatchlistActionButton
               visibilityClassName="size-8 sm:size-10 shrink-0"
               isAddMode={isAddMode}

--- a/frontend/src/app/(user)/watchlist/components/watchlist-item.tsx
+++ b/frontend/src/app/(user)/watchlist/components/watchlist-item.tsx
@@ -54,7 +54,6 @@ export default function WatchlistItem({
       quantity={quantityWithUnit}
       isLoading={isLoading}
       onClick={() => navigateToProduct(productApiId, product)}
-      trailingWraps
       trailing={
         <>
           <WatchlistItemDiscountInfo

--- a/frontend/src/app/(user)/watchlist/components/watchlist-threshold-badges.tsx
+++ b/frontend/src/app/(user)/watchlist/components/watchlist-threshold-badges.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { MouseEvent } from "react";
+import { Pencil } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { WatchType } from "@/lib/api";
+import { WatchlistItemDto } from "@/lib/api/types";
+
+interface IWatchlistThresholdBadgesProps {
+  items: WatchlistItemDto[];
+  disabled: boolean;
+  isAchieved: (thresholdValue: number, watchType: WatchType) => boolean;
+  onEdit: (event: MouseEvent<HTMLButtonElement>, watchType: WatchType) => void;
+}
+
+export default function WatchlistThresholdBadges({
+  items,
+  disabled,
+  isAchieved,
+  onEdit,
+}: IWatchlistThresholdBadgesProps) {
+  const sortedItems = [...items].sort((a, b) => {
+    if (a.watchType === b.watchType) return 0;
+
+    return a.watchType === WatchType.percentage ? -1 : 1;
+  });
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-2">
+      {sortedItems.map((item) => (
+        <Badge
+          key={item.id}
+          variant="outline"
+          asChild
+          className={cn(
+            "text-xs cursor-pointer gap-2",
+            isAchieved(item.thresholdValue, item.watchType) &&
+              "border-green-600 bg-green-50 text-green-700 font-bold",
+          )}
+        >
+          <button
+            type="button"
+            onClick={(event) => onEdit(event, item.watchType)}
+            disabled={disabled}
+          >
+            {item.watchType === "ABSOLUTE"
+              ? `- ${item.thresholdValue.toFixed(2)}€`
+              : `- ${Math.round(item.thresholdValue)}%`}
+            <Pencil className="size-3" />
+          </button>
+        </Badge>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/app/(user)/watchlist/components/watchlist-threshold-badges.tsx
+++ b/frontend/src/app/(user)/watchlist/components/watchlist-threshold-badges.tsx
@@ -45,10 +45,10 @@ export default function WatchlistThresholdBadges({
             onClick={(event) => onEdit(event, item.watchType)}
             disabled={disabled}
           >
-            {item.watchType === "ABSOLUTE"
+            {item.watchType === WatchType.absolute
               ? `- ${item.thresholdValue.toFixed(2)}€`
               : `- ${Math.round(item.thresholdValue)}%`}
-            <Pencil className="size-3" />
+            <Pencil className="size-3" aria-hidden="true" />
           </button>
         </Badge>
       ))}

--- a/frontend/src/app/(user)/watchlist/hooks/use-watchlist-item.ts
+++ b/frontend/src/app/(user)/watchlist/hooks/use-watchlist-item.ts
@@ -8,6 +8,7 @@ import {
   IWatchlistItemWithProduct,
 } from "@/app/(user)/watchlist/utils/watchlist-utils";
 import { getMostFrequentCategory } from "@/app/products/utils/product-utils";
+import { toStoreLines } from "@/app/(user)/watchlist/utils/discount-display-utils";
 import useWatchlistRemoval from "@/app/(user)/watchlist/hooks/use-watchlist-removal";
 import { useUser } from "@/context/user-context";
 import { openModalUrl } from "@/lib/modal/modal-navigation";
@@ -37,11 +38,17 @@ export function useWatchlistItem(item: IWatchlistItemWithProduct) {
   const category = product ? getMostFrequentCategory(product) : null;
 
   const preferredStores = product
-    ? getScopedDiscountedStores(product, pinnedStoreChainCodes, true)
+    ? toStoreLines(
+        getScopedDiscountedStores(product, pinnedStoreChainCodes, true),
+        watchlistItems,
+      )
     : [];
 
   const totalStores = product
-    ? getScopedDiscountedStores(product, [], false)
+    ? toStoreLines(
+        getScopedDiscountedStores(product, [], false),
+        watchlistItems,
+      )
     : [];
 
   function isWatchRequirementAchieved(

--- a/frontend/src/app/(user)/watchlist/hooks/use-watchlist-item.ts
+++ b/frontend/src/app/(user)/watchlist/hooks/use-watchlist-item.ts
@@ -1,12 +1,14 @@
-import { useState, MouseEvent } from "react";
-import { toast } from "sonner";
-import { useQueryClient } from "@tanstack/react-query";
-import { watchlistService, WatchType } from "@/lib/api";
+import { MouseEvent } from "react";
+
+import { WatchType } from "@/lib/api";
 import {
   extractPinnedStoreChainCodes,
+  getScopedDiscountedStores,
   isWatchThresholdReached,
   IWatchlistItemWithProduct,
 } from "@/app/(user)/watchlist/utils/watchlist-utils";
+import { getMostFrequentCategory } from "@/app/products/utils/product-utils";
+import useWatchlistRemoval from "@/app/(user)/watchlist/hooks/use-watchlist-removal";
 import { useUser } from "@/context/user-context";
 import { openModalUrl } from "@/lib/modal/modal-navigation";
 import { formatQuantity } from "@/utils/strings";
@@ -14,43 +16,9 @@ import { formatQuantity } from "@/utils/strings";
 export function useWatchlistItem(item: IWatchlistItemWithProduct) {
   const { watchlistItems, productApiId, product, discountInfo, isLoading } =
     item;
-  const queryClient = useQueryClient();
   const { user } = useUser();
-  const [isRemoving, setIsRemoving] = useState(false);
 
-  async function handleRemove() {
-    setIsRemoving(true);
-
-    try {
-      const removeResults = await Promise.allSettled(
-        watchlistItems.map((watchlistItem) =>
-          watchlistService.removeFromWatchlist(watchlistItem.id),
-        ),
-      );
-
-      const failedRemovals = removeResults.filter(
-        (result) => result.status === "rejected",
-      ).length;
-
-      if (failedRemovals === 0) {
-        toast.success("Proizvod uklonjen s popisa za praćenje");
-      } else if (failedRemovals === watchlistItems.length) {
-        toast.error("Greška pri uklanjanju proizvoda");
-      } else {
-        toast.error(
-          `Djelomično uklanjanje: ${failedRemovals} stavki nije moguće ukloniti.`,
-        );
-      }
-    } catch {
-      toast.error("Greška pri uklanjanju proizvoda");
-    } finally {
-      await queryClient.invalidateQueries({
-        queryKey: watchlistService.QUERY_KEYS.all,
-      });
-
-      setIsRemoving(false);
-    }
-  }
+  const { isRemoving, handleRemove } = useWatchlistRemoval(watchlistItems);
 
   const productName =
     product?.name || (isLoading ? "Učitavanje..." : "Proizvod nije dostupan");
@@ -61,8 +29,20 @@ export function useWatchlistItem(item: IWatchlistItemWithProduct) {
       ? `${formattedQuantity}${product.unit}`
       : null;
 
-  const hasPinnedStores =
-    extractPinnedStoreChainCodes(user?.pinnedStores).length > 0;
+  const pinnedStoreChainCodes = extractPinnedStoreChainCodes(
+    user?.pinnedStores,
+  );
+  const hasPinnedStores = pinnedStoreChainCodes.length > 0;
+
+  const category = product ? getMostFrequentCategory(product) : null;
+
+  const preferredStores = product
+    ? getScopedDiscountedStores(product, pinnedStoreChainCodes, true)
+    : [];
+
+  const totalStores = product
+    ? getScopedDiscountedStores(product, [], false)
+    : [];
 
   function isWatchRequirementAchieved(
     thresholdValue: number,
@@ -116,7 +96,10 @@ export function useWatchlistItem(item: IWatchlistItemWithProduct) {
     productName,
     productBrand,
     quantityWithUnit,
+    category,
     hasPinnedStores,
+    preferredStores,
+    totalStores,
     isWatchRequirementAchieved,
     handleBadgeClick,
     handleOpenWatchlistModal,

--- a/frontend/src/app/(user)/watchlist/hooks/use-watchlist-item.ts
+++ b/frontend/src/app/(user)/watchlist/hooks/use-watchlist-item.ts
@@ -40,15 +40,11 @@ export function useWatchlistItem(item: IWatchlistItemWithProduct) {
   const preferredStores = product
     ? toStoreLines(
         getScopedDiscountedStores(product, pinnedStoreChainCodes, true),
-        watchlistItems,
       )
     : [];
 
   const totalStores = product
-    ? toStoreLines(
-        getScopedDiscountedStores(product, [], false),
-        watchlistItems,
-      )
+    ? toStoreLines(getScopedDiscountedStores(product, [], false))
     : [];
 
   function isWatchRequirementAchieved(

--- a/frontend/src/app/(user)/watchlist/hooks/use-watchlist-removal.ts
+++ b/frontend/src/app/(user)/watchlist/hooks/use-watchlist-removal.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { watchlistService } from "@/lib/api";
+import { WatchlistItemDto } from "@/lib/api/types";
+
+export default function useWatchlistRemoval(
+  watchlistItems: WatchlistItemDto[],
+) {
+  const queryClient = useQueryClient();
+  const [isRemoving, setIsRemoving] = useState(false);
+
+  async function handleRemove() {
+    setIsRemoving(true);
+
+    try {
+      const results = await Promise.allSettled(
+        watchlistItems.map((watchlistItem) =>
+          watchlistService.removeFromWatchlist(watchlistItem.id),
+        ),
+      );
+
+      const failed = results.filter(
+        (result) => result.status === "rejected",
+      ).length;
+
+      if (failed === 0) {
+        toast.success("Proizvod uklonjen s popisa za praćenje");
+      } else if (failed === watchlistItems.length) {
+        toast.error("Greška pri uklanjanju proizvoda");
+      } else {
+        toast.error(
+          `Djelomično uklanjanje: ${failed} stavki nije moguće ukloniti.`,
+        );
+      }
+    } catch {
+      toast.error("Greška pri uklanjanju proizvoda");
+    } finally {
+      await queryClient.invalidateQueries({
+        queryKey: watchlistService.QUERY_KEYS.all,
+      });
+
+      setIsRemoving(false);
+    }
+  }
+
+  return { isRemoving, handleRemove };
+}

--- a/frontend/src/app/(user)/watchlist/utils/discount-display-utils.ts
+++ b/frontend/src/app/(user)/watchlist/utils/discount-display-utils.ts
@@ -1,4 +1,5 @@
 import { getChainLabel } from "@/utils/labels";
+import { formatPriceDelta } from "@/utils/price";
 import { IScopedDiscountedStore } from "@/app/(user)/watchlist/typings/watchlist-types";
 import type { INotificationStore } from "@/context/notifications-types";
 
@@ -22,5 +23,5 @@ export function formatDifference(
     return fallback;
   }
 
-  return `${difference > 0 ? "+" : ""}${difference.toFixed(2)}€ (${Math.round(Math.abs(percentage))}%)`;
+  return formatPriceDelta(difference, percentage);
 }

--- a/frontend/src/app/(user)/watchlist/utils/discount-display-utils.ts
+++ b/frontend/src/app/(user)/watchlist/utils/discount-display-utils.ts
@@ -1,0 +1,26 @@
+import { getChainLabel } from "@/utils/labels";
+import { IScopedDiscountedStore } from "@/app/(user)/watchlist/typings/watchlist-types";
+import type { INotificationStore } from "@/context/notifications-types";
+
+export function toStoreLines(
+  stores: IScopedDiscountedStore[],
+): INotificationStore[] {
+  return stores.map((store) => ({
+    chainName: getChainLabel(store.chain.chain),
+    currentPrice: store.currentPrice,
+    discountAmount: store.discountAmount,
+    discountPercentage: store.discountPercentage,
+  }));
+}
+
+export function formatDifference(
+  difference: number | null,
+  percentage: number | null,
+  fallback: string,
+): string {
+  if (difference === null || percentage === null) {
+    return fallback;
+  }
+
+  return `${difference > 0 ? "+" : ""}${difference.toFixed(2)}€ (${Math.round(Math.abs(percentage))}%)`;
+}

--- a/frontend/src/app/(user)/watchlist/utils/discount-display-utils.ts
+++ b/frontend/src/app/(user)/watchlist/utils/discount-display-utils.ts
@@ -1,15 +1,26 @@
 import { getChainLabel } from "@/utils/labels";
+import { isDiscountValueAboveThreshold } from "@/app/(user)/watchlist/utils/watchlist-utils";
 import { IScopedDiscountedStore } from "@/app/(user)/watchlist/typings/watchlist-types";
+import { WatchlistItemDto } from "@/lib/api/types";
 import type { INotificationStore } from "@/context/notifications-types";
 
 export function toStoreLines(
   stores: IScopedDiscountedStore[],
+  watchlistItems: WatchlistItemDto[],
 ): INotificationStore[] {
   return stores.map((store) => ({
     chainName: getChainLabel(store.chain.chain),
     currentPrice: store.currentPrice,
     discountAmount: store.discountAmount,
     discountPercentage: store.discountPercentage,
+    meetsThreshold: watchlistItems.some((item) =>
+      isDiscountValueAboveThreshold(
+        store.discountAmount,
+        store.discountPercentage,
+        item.watchType,
+        item.thresholdValue,
+      ),
+    ),
   }));
 }
 

--- a/frontend/src/app/(user)/watchlist/utils/discount-display-utils.ts
+++ b/frontend/src/app/(user)/watchlist/utils/discount-display-utils.ts
@@ -1,26 +1,15 @@
 import { getChainLabel } from "@/utils/labels";
-import { isDiscountValueAboveThreshold } from "@/app/(user)/watchlist/utils/watchlist-utils";
 import { IScopedDiscountedStore } from "@/app/(user)/watchlist/typings/watchlist-types";
-import { WatchlistItemDto } from "@/lib/api/types";
 import type { INotificationStore } from "@/context/notifications-types";
 
 export function toStoreLines(
   stores: IScopedDiscountedStore[],
-  watchlistItems: WatchlistItemDto[],
 ): INotificationStore[] {
   return stores.map((store) => ({
     chainName: getChainLabel(store.chain.chain),
     currentPrice: store.currentPrice,
     discountAmount: store.discountAmount,
     discountPercentage: store.discountPercentage,
-    meetsThreshold: watchlistItems.some((item) =>
-      isDiscountValueAboveThreshold(
-        store.discountAmount,
-        store.discountPercentage,
-        item.watchType,
-        item.thresholdValue,
-      ),
-    ),
   }));
 }
 

--- a/frontend/src/app/(user)/watchlist/utils/watchlist-discount-utils.ts
+++ b/frontend/src/app/(user)/watchlist/utils/watchlist-discount-utils.ts
@@ -18,7 +18,7 @@ export function getScopedDiscountedStores(
   pinnedStoreChainCodes: string[],
   hasPinnedStores: boolean,
 ): IScopedDiscountedStore[] {
-  const avgPrice = getAveragePrice(product);
+  const avgPrice = getAveragePrice(product) ?? 0;
 
   if (avgPrice <= 0) {
     return [];
@@ -60,7 +60,7 @@ export function calculateDiscountInfo(
   product: ProductResponse,
   pinnedStoreChainCodes: string[],
 ): IDiscountInfo {
-  const avgPrice = getAveragePrice(product);
+  const avgPrice = getAveragePrice(product) ?? 0;
 
   const cheapestOverall = getCheapestChainByMinPrice(product.chains);
   const preferredChains = product.chains.filter((chain) =>

--- a/frontend/src/app/products/[id]/components/price-history/price-history-controls.tsx
+++ b/frontend/src/app/products/[id]/components/price-history/price-history-controls.tsx
@@ -4,7 +4,7 @@ import PriceChangeDisplay from "@/components/custom/price/price-change-display";
 import { DISABLED_PERIODS } from "@/constants/price-history";
 
 interface IPriceHistoryControlsProps {
-  priceChange: { difference: number; percentage: number } | null;
+  priceChange: { difference: number; percentage: number | null } | null;
   chains: string[];
   selectedChains: string[];
   onChainsChange: (chains: string[]) => void;

--- a/frontend/src/app/products/components/forms/watchlist-item-modal.tsx
+++ b/frontend/src/app/products/components/forms/watchlist-item-modal.tsx
@@ -59,8 +59,8 @@ export default function WatchlistItemModal({
   const productQuery = cijeneService.useGetProductByEan({ ean });
   const product = productQuery.data;
 
-  const avgPrice = product ? getAveragePrice(product) : 0;
-  const minPrice = product ? getMinPrice(product) : 0;
+  const avgPrice = product ? (getAveragePrice(product) ?? 0) : 0;
+  const minPrice = product ? (getMinPrice(product) ?? 0) : 0;
 
   const {
     form,

--- a/frontend/src/app/products/components/product-info-display.tsx
+++ b/frontend/src/app/products/components/product-info-display.tsx
@@ -1,6 +1,7 @@
-import { useMemo, type ReactNode } from "react";
+import { type ReactNode } from "react";
 
 import { ProductResponse } from "@/lib/cijene-api/schemas";
+import { getMostFrequentCategory } from "@/app/products/utils/product-utils";
 import ProductActionButtons from "@/app/products/components/product-action-buttons";
 import ProductInfoTable from "@/app/products/components/product-info-table";
 import { Button } from "@/components/ui/button";
@@ -21,39 +22,15 @@ export default function ProductInfoDisplay({
 }: IProductInfoDisplayProps) {
   const router = useRouter();
 
-  const handleBackClick = () => {
+  function handleBackClick() {
     if (window.history.length > 1) {
       router.back();
     } else {
       router.push("/");
     }
-  };
+  }
 
-  // Get the most common category from chains (similar to ProductCard logic)
-  const category = useMemo(() => {
-    if (!product.chains || product.chains.length === 0) return null;
-
-    const categoryCount: Record<string, number> = {};
-
-    product.chains.forEach((chain) => {
-      if (chain.category) {
-        categoryCount[chain.category] =
-          (categoryCount[chain.category] || 0) + 1;
-      }
-    });
-
-    let mostFrequentCategory = null;
-    let maxCount = 0;
-
-    for (const [cat, count] of Object.entries(categoryCount)) {
-      if (count > maxCount) {
-        maxCount = count;
-        mostFrequentCategory = cat;
-      }
-    }
-
-    return mostFrequentCategory;
-  }, [product.chains]);
+  const category = getMostFrequentCategory(product);
 
   return (
     <div className="space-y-4">

--- a/frontend/src/app/products/components/product-info-table.tsx
+++ b/frontend/src/app/products/components/product-info-table.tsx
@@ -47,7 +47,7 @@ export default function ProductInfoTable({ product }: IProductInfoTableProps) {
               </td>
               <td className="p-2 flex-1">
                 <span className="font-bold">Cijene: </span>
-                {product.chains.length > 0 ? (
+                {minPrice !== null && maxPrice !== null ? (
                   minPrice === maxPrice ? (
                     <span className="whitespace-nowrap text-gray-700">
                       {minPrice.toFixed(2)}€

--- a/frontend/src/app/products/components/product-info-table.tsx
+++ b/frontend/src/app/products/components/product-info-table.tsx
@@ -77,23 +77,29 @@ export default function ProductInfoTable({ product }: IProductInfoTableProps) {
             <tr className="flex flex-col sm:table-row">
               <td className="p-2 flex-1">
                 <span className="font-bold">Jed. cijene: </span>
-                {minPricePerUnit === maxPricePerUnit ? (
-                  <span className="whitespace-nowrap text-gray-700">
-                    {minPricePerUnit?.toFixed(2)}€/{product.unit}
-                  </span>
+                {minPricePerUnit !== undefined &&
+                maxPricePerUnit !== undefined ? (
+                  minPricePerUnit === maxPricePerUnit ? (
+                    <span className="whitespace-nowrap text-gray-700">
+                      {minPricePerUnit.toFixed(2)}€/{product.unit}
+                    </span>
+                  ) : (
+                    <span className="whitespace-nowrap">
+                      <span className="text-green-700">
+                        {minPricePerUnit.toFixed(2)}€/{product.unit}
+                      </span>
+                      <span className="text-gray-700">
+                        {" "}
+                        | {averagePricePerUnit?.toFixed(2)}€/{product.unit}{" "}
+                        |{" "}
+                      </span>
+                      <span className="text-red-700">
+                        {maxPricePerUnit.toFixed(2)}€/{product.unit}
+                      </span>
+                    </span>
+                  )
                 ) : (
-                  <span className="whitespace-nowrap">
-                    <span className="text-green-700">
-                      {minPricePerUnit?.toFixed(2)}€/{product.unit}
-                    </span>
-                    <span className="text-gray-700">
-                      {" "}
-                      | {averagePricePerUnit?.toFixed(2)}€/{product.unit} |{" "}
-                    </span>
-                    <span className="text-red-700">
-                      {maxPricePerUnit?.toFixed(2)}€/{product.unit}
-                    </span>
-                  </span>
+                  "Nepoznato"
                 )}
               </td>
             </tr>

--- a/frontend/src/app/products/components/product-item/product-item.tsx
+++ b/frontend/src/app/products/components/product-item/product-item.tsx
@@ -1,96 +1,43 @@
 "use client";
 
-import { memo, useMemo } from "react";
-import { useRouter } from "next/navigation";
-import { Card } from "@/components/ui/card";
+import { memo } from "react";
+
 import { ProductResponse } from "@/lib/cijene-api/schemas";
-import { productByEanQueryKey } from "@/lib/cijene-api";
-import ProductInfo from "@/app/products/components/product-item/product-info";
+import { getMostFrequentCategory } from "@/app/products/utils/product-utils";
+import ProductCard from "@/components/custom/product/product-card";
 import ProductUnitPriceDetails from "@/app/products/components/product-item/product-price";
-import { useQueryClient } from "@tanstack/react-query";
 import ProductActionButtons from "@/app/products/components/product-action-buttons";
+import useProductNavigation from "@/hooks/use-product-navigation";
 
 interface IProductItemProps {
   product: ProductResponse;
 }
 
 const ProductItem = memo(function ProductItem({ product }: IProductItemProps) {
-  const router = useRouter();
-  const queryClient = useQueryClient();
+  const navigateToProduct = useProductNavigation();
 
-  // Get category that appears most often in product.chains
-  const category = useMemo(() => {
-    if (!product.chains || product.chains.length === 0) return null;
-
-    const categoryCount: Record<string, number> = {};
-
-    // Count frequency of each category
-    product.chains.forEach((chain) => {
-      if (chain.category) {
-        categoryCount[chain.category] =
-          (categoryCount[chain.category] || 0) + 1;
-      }
-    });
-
-    // Find category with highest count
-    let mostFrequentCategory = null;
-    let maxCount = 0;
-
-    for (const [cat, count] of Object.entries(categoryCount)) {
-      if (count > maxCount) {
-        maxCount = count;
-        mostFrequentCategory = cat;
-      }
-    }
-
-    return mostFrequentCategory;
-  }, [product.chains]);
-
-  const handleProductClick = () => {
-    // Pre-populate the React Query cache with the product data
-    queryClient.setQueryData(productByEanQueryKey(product.ean), product);
-
-    // Navigate to the product details page
-    router.push(`/products/${product.ean}`);
-  };
+  const category = getMostFrequentCategory(product);
 
   return (
-    <Card
-      onClick={handleProductClick}
-      className="cursor-pointer px-3 sm:px-6 py-2 sm:py-4 hover:shadow-lg shadow-sm transition-shadow"
-    >
-      <div className="flex sm:items-center justify-between gap-2 sm:gap-4 flex-col sm:flex-row">
-        <div className="flex items-center justify-between sm:gap-8 gap-4 flex-1">
-          {/* TODO: Product Image */}
-          {/* <div className="size-20 bg-gray-100 rounded-lg hidden sm:grid place-items-center">
-              <span className="text-gray-400">IMG</span>
-            </div> */}
-
-          <ProductInfo
-            name={product.name}
-            brand={product.brand}
-            category={category}
-          />
-
+    <ProductCard
+      name={product.name}
+      brand={product.brand}
+      category={category}
+      onClick={() => navigateToProduct(product.ean, product)}
+      trailing={
+        <>
           <ProductUnitPriceDetails product={product} />
 
-          {/* Icon buttons */}
-          <div
-            onClick={(e) => {
-              e.stopPropagation();
-            }}
-          >
-            <ProductActionButtons
-              product={product}
-              showSearchImage={true}
-              showAddToList={true}
-              showAddToWatchlist={false}
-              className="flex-col sm:flex-row"
-            />
-          </div>
-        </div>
-      </div>
-    </Card>
+          <ProductActionButtons
+            product={product}
+            showSearchImage={true}
+            showAddToList={true}
+            showAddToWatchlist={false}
+            className="flex-col sm:flex-row"
+          />
+        </>
+      }
+    />
   );
 });
 

--- a/frontend/src/app/products/utils/price-comparison-types.ts
+++ b/frontend/src/app/products/utils/price-comparison-types.ts
@@ -1,0 +1,1 @@
+export type PriceExtreme = "min" | "max" | null;

--- a/frontend/src/app/products/utils/price-comparison-utils.ts
+++ b/frontend/src/app/products/utils/price-comparison-utils.ts
@@ -2,9 +2,9 @@ import { PriceExtreme } from "@/app/products/utils/price-comparison-types";
 
 // Uniform prices (min === max) return null so every view renders them neutrally.
 export function getPriceExtreme(
-  value: number,
-  min: number,
-  max: number,
+  value: number | null,
+  min: number | null,
+  max: number | null,
 ): PriceExtreme {
   if (![value, min, max].every(Number.isFinite)) {
     return null;

--- a/frontend/src/app/products/utils/price-comparison-utils.ts
+++ b/frontend/src/app/products/utils/price-comparison-utils.ts
@@ -1,0 +1,38 @@
+export type PriceExtreme = "min" | "max" | null;
+
+// Uniform prices (min === max) return null so every view renders them neutrally.
+export function getPriceExtreme(
+  value: number,
+  min: number,
+  max: number,
+): PriceExtreme {
+  if (![value, min, max].every(Number.isFinite)) {
+    return null;
+  }
+
+  if (min === max) {
+    return null;
+  }
+
+  if (value === min) {
+    return "min";
+  }
+
+  if (value === max) {
+    return "max";
+  }
+
+  return null;
+}
+
+export function calculatePriceChange(
+  currentPrice: number,
+  previousPrice: number,
+) {
+  const percentage = Math.abs(
+    ((currentPrice - previousPrice) / previousPrice) * 100,
+  );
+  const difference = Number((currentPrice - previousPrice).toFixed(2));
+
+  return { percentage, difference };
+}

--- a/frontend/src/app/products/utils/price-comparison-utils.ts
+++ b/frontend/src/app/products/utils/price-comparison-utils.ts
@@ -1,4 +1,4 @@
-export type PriceExtreme = "min" | "max" | null;
+import { PriceExtreme } from "@/app/products/utils/price-comparison-types";
 
 // Uniform prices (min === max) return null so every view renders them neutrally.
 export function getPriceExtreme(
@@ -29,10 +29,11 @@ export function calculatePriceChange(
   currentPrice: number,
   previousPrice: number,
 ) {
-  const percentage = Math.abs(
-    ((currentPrice - previousPrice) / previousPrice) * 100,
-  );
   const difference = Number((currentPrice - previousPrice).toFixed(2));
+  const percentage =
+    previousPrice === 0
+      ? null
+      : Math.abs(((currentPrice - previousPrice) / previousPrice) * 100);
 
   return { percentage, difference };
 }

--- a/frontend/src/app/products/utils/product-category-utils.ts
+++ b/frontend/src/app/products/utils/product-category-utils.ts
@@ -1,0 +1,29 @@
+import { ProductResponse } from "@/lib/cijene-api/schemas";
+
+export function getMostFrequentCategory(
+  product: ProductResponse,
+): string | null {
+  if (!product.chains || product.chains.length === 0) {
+    return null;
+  }
+
+  const categoryCount: Record<string, number> = {};
+
+  for (const chain of product.chains) {
+    if (chain.category) {
+      categoryCount[chain.category] = (categoryCount[chain.category] || 0) + 1;
+    }
+  }
+
+  let mostFrequentCategory: string | null = null;
+  let maxCount = 0;
+
+  for (const [category, count] of Object.entries(categoryCount)) {
+    if (count > maxCount) {
+      maxCount = count;
+      mostFrequentCategory = category;
+    }
+  }
+
+  return mostFrequentCategory;
+}

--- a/frontend/src/app/products/utils/product-price-utils.ts
+++ b/frontend/src/app/products/utils/product-price-utils.ts
@@ -1,0 +1,98 @@
+import {
+  ChainProductResponse,
+  ProductResponse,
+} from "@/lib/cijene-api/schemas";
+
+const minPriceCache = new WeakMap<ProductResponse, number>();
+const maxPriceCache = new WeakMap<ProductResponse, number>();
+const avgPriceCache = new WeakMap<ProductResponse, number>();
+
+export function parsePrice(value: string): number | null {
+  const parsed = Number.parseFloat(value);
+
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export function getMinPrice(product: ProductResponse): number {
+  if (minPriceCache.has(product)) {
+    return minPriceCache.get(product)!;
+  }
+
+  const prices = product.chains
+    .map((c) => parseFloat(c.min_price))
+    .filter((price) => Number.isFinite(price));
+  const min = prices.length > 0 ? Math.min(...prices) : 0;
+  const finalMin = Number.isFinite(min) ? min : 0;
+
+  minPriceCache.set(product, finalMin);
+  return finalMin;
+}
+
+export function getMaxPrice(product: ProductResponse): number {
+  if (maxPriceCache.has(product)) {
+    return maxPriceCache.get(product)!;
+  }
+
+  const prices = product.chains
+    .map((c) => parseFloat(c.max_price))
+    .filter((price) => Number.isFinite(price));
+  const max = prices.length > 0 ? Math.max(...prices) : 0;
+  const finalMax = Number.isFinite(max) ? max : 0;
+
+  maxPriceCache.set(product, finalMax);
+  return finalMax;
+}
+
+export function getAveragePrice(product: ProductResponse): number {
+  if (avgPriceCache.has(product)) {
+    return avgPriceCache.get(product)!;
+  }
+
+  if (product.chains.length > 0) {
+    let sum = 0;
+    let count = 0;
+
+    for (const chain of product.chains) {
+      const parsed = parseFloat(chain.avg_price);
+      if (Number.isFinite(parsed)) {
+        sum += parsed;
+        count += 1;
+      }
+    }
+
+    const avg = sum / count;
+    if (Number.isFinite(avg)) {
+      avgPriceCache.set(product, avg);
+      return avg;
+    }
+  }
+
+  return 0;
+}
+
+export function getCheapestChainByMinPrice(
+  chains: ChainProductResponse[],
+): { chain: ChainProductResponse; price: number } | null {
+  const pricedChains: Array<{ chain: ChainProductResponse; price: number }> =
+    [];
+
+  for (const chain of chains) {
+    const price = parsePrice(chain.min_price);
+
+    if (price !== null) {
+      pricedChains.push({ chain, price });
+    }
+  }
+
+  if (pricedChains.length === 0) {
+    return null;
+  }
+
+  return pricedChains.reduce((lowest, current) =>
+    current.price < lowest.price ? current : lowest,
+  );
+}

--- a/frontend/src/app/products/utils/product-price-utils.ts
+++ b/frontend/src/app/products/utils/product-price-utils.ts
@@ -3,9 +3,9 @@ import {
   ProductResponse,
 } from "@/lib/cijene-api/schemas";
 
-const minPriceCache = new WeakMap<ProductResponse, number>();
-const maxPriceCache = new WeakMap<ProductResponse, number>();
-const avgPriceCache = new WeakMap<ProductResponse, number>();
+const minPriceCache = new WeakMap<ProductResponse, number | null>();
+const maxPriceCache = new WeakMap<ProductResponse, number | null>();
+const avgPriceCache = new WeakMap<ProductResponse, number | null>();
 
 export function parsePrice(value: string): number | null {
   const parsed = Number.parseFloat(value);
@@ -17,61 +17,49 @@ export function parsePrice(value: string): number | null {
   return parsed;
 }
 
-export function getMinPrice(product: ProductResponse): number {
+export function getMinPrice(product: ProductResponse): number | null {
   if (minPriceCache.has(product)) {
     return minPriceCache.get(product)!;
   }
 
   const prices = product.chains
-    .map((c) => parseFloat(c.min_price))
-    .filter((price) => Number.isFinite(price));
-  const min = prices.length > 0 ? Math.min(...prices) : 0;
-  const finalMin = Number.isFinite(min) ? min : 0;
+    .map((chain) => parsePrice(chain.min_price))
+    .filter((price): price is number => price !== null);
+  const min = prices.length > 0 ? Math.min(...prices) : null;
 
-  minPriceCache.set(product, finalMin);
-  return finalMin;
+  minPriceCache.set(product, min);
+  return min;
 }
 
-export function getMaxPrice(product: ProductResponse): number {
+export function getMaxPrice(product: ProductResponse): number | null {
   if (maxPriceCache.has(product)) {
     return maxPriceCache.get(product)!;
   }
 
   const prices = product.chains
-    .map((c) => parseFloat(c.max_price))
-    .filter((price) => Number.isFinite(price));
-  const max = prices.length > 0 ? Math.max(...prices) : 0;
-  const finalMax = Number.isFinite(max) ? max : 0;
+    .map((chain) => parsePrice(chain.max_price))
+    .filter((price): price is number => price !== null);
+  const max = prices.length > 0 ? Math.max(...prices) : null;
 
-  maxPriceCache.set(product, finalMax);
-  return finalMax;
+  maxPriceCache.set(product, max);
+  return max;
 }
 
-export function getAveragePrice(product: ProductResponse): number {
+export function getAveragePrice(product: ProductResponse): number | null {
   if (avgPriceCache.has(product)) {
     return avgPriceCache.get(product)!;
   }
 
-  if (product.chains.length > 0) {
-    let sum = 0;
-    let count = 0;
+  const prices = product.chains
+    .map((chain) => parsePrice(chain.avg_price))
+    .filter((price): price is number => price !== null);
+  const avg =
+    prices.length > 0
+      ? prices.reduce((sum, price) => sum + price, 0) / prices.length
+      : null;
 
-    for (const chain of product.chains) {
-      const parsed = parseFloat(chain.avg_price);
-      if (Number.isFinite(parsed)) {
-        sum += parsed;
-        count += 1;
-      }
-    }
-
-    const avg = sum / count;
-    if (Number.isFinite(avg)) {
-      avgPriceCache.set(product, avg);
-      return avg;
-    }
-  }
-
-  return 0;
+  avgPriceCache.set(product, avg);
+  return avg;
 }
 
 export function getCheapestChainByMinPrice(

--- a/frontend/src/app/products/utils/product-unit-price-utils.ts
+++ b/frontend/src/app/products/utils/product-unit-price-utils.ts
@@ -5,38 +5,28 @@ import {
   getMinPrice,
 } from "@/app/products/utils/product-price-utils";
 
+function perUnit(price: number | null, quantity: number): number | undefined {
+  if (price === null || !Number.isFinite(quantity) || quantity <= 0) {
+    return undefined;
+  }
+
+  return price / quantity;
+}
+
 export function getMinPricePerUnit(
   product: ProductResponse,
 ): number | undefined {
-  const quantity = Number(product.quantity);
-
-  if (Number.isFinite(quantity) && quantity > 0) {
-    return getMinPrice(product) / quantity;
-  }
-
-  return undefined;
+  return perUnit(getMinPrice(product), Number(product.quantity));
 }
 
 export function getMaxPricePerUnit(
   product: ProductResponse,
 ): number | undefined {
-  const quantity = Number(product.quantity);
-
-  if (Number.isFinite(quantity) && quantity > 0) {
-    return getMaxPrice(product) / quantity;
-  }
-
-  return undefined;
+  return perUnit(getMaxPrice(product), Number(product.quantity));
 }
 
 export function getAveragePricePerUnit(
   product: ProductResponse,
 ): number | undefined {
-  const quantity = Number(product.quantity);
-
-  if (Number.isFinite(quantity) && quantity > 0) {
-    return getAveragePrice(product) / quantity;
-  }
-
-  return undefined;
+  return perUnit(getAveragePrice(product), Number(product.quantity));
 }

--- a/frontend/src/app/products/utils/product-unit-price-utils.ts
+++ b/frontend/src/app/products/utils/product-unit-price-utils.ts
@@ -1,0 +1,42 @@
+import { ProductResponse } from "@/lib/cijene-api/schemas";
+import {
+  getAveragePrice,
+  getMaxPrice,
+  getMinPrice,
+} from "@/app/products/utils/product-price-utils";
+
+export function getMinPricePerUnit(
+  product: ProductResponse,
+): number | undefined {
+  const quantity = Number(product.quantity);
+
+  if (Number.isFinite(quantity) && quantity > 0) {
+    return getMinPrice(product) / quantity;
+  }
+
+  return undefined;
+}
+
+export function getMaxPricePerUnit(
+  product: ProductResponse,
+): number | undefined {
+  const quantity = Number(product.quantity);
+
+  if (Number.isFinite(quantity) && quantity > 0) {
+    return getMaxPrice(product) / quantity;
+  }
+
+  return undefined;
+}
+
+export function getAveragePricePerUnit(
+  product: ProductResponse,
+): number | undefined {
+  const quantity = Number(product.quantity);
+
+  if (Number.isFinite(quantity) && quantity > 0) {
+    return getAveragePrice(product) / quantity;
+  }
+
+  return undefined;
+}

--- a/frontend/src/app/products/utils/product-utils.ts
+++ b/frontend/src/app/products/utils/product-utils.ts
@@ -15,7 +15,8 @@ export {
 export {
   getPriceExtreme,
   calculatePriceChange,
-  type PriceExtreme,
 } from "@/app/products/utils/price-comparison-utils";
+
+export type { PriceExtreme } from "@/app/products/utils/price-comparison-types";
 
 export { getMostFrequentCategory } from "@/app/products/utils/product-category-utils";

--- a/frontend/src/app/products/utils/product-utils.ts
+++ b/frontend/src/app/products/utils/product-utils.ts
@@ -1,199 +1,21 @@
-import {
-  ChainProductResponse,
-  ProductResponse,
-} from "@/lib/cijene-api/schemas";
+export {
+  parsePrice,
+  getMinPrice,
+  getMaxPrice,
+  getAveragePrice,
+  getCheapestChainByMinPrice,
+} from "@/app/products/utils/product-price-utils";
 
-// Memoization caches
-const minPriceCache = new WeakMap<ProductResponse, number>();
-const maxPriceCache = new WeakMap<ProductResponse, number>();
-const avgPriceCache = new WeakMap<ProductResponse, number>();
+export {
+  getMinPricePerUnit,
+  getMaxPricePerUnit,
+  getAveragePricePerUnit,
+} from "@/app/products/utils/product-unit-price-utils";
 
-/**
- * Get minimum price for a product from Cijene API
- */
-export function getMinPrice(product: ProductResponse): number {
-  if (minPriceCache.has(product)) {
-    return minPriceCache.get(product)!;
-  }
-  const prices = product.chains
-    .map((c) => parseFloat(c.min_price))
-    .filter((price) => Number.isFinite(price));
-  const min = prices.length > 0 ? Math.min(...prices) : 0;
-  const finalMin = Number.isFinite(min) ? min : 0;
-  minPriceCache.set(product, finalMin);
-  return finalMin;
-}
+export {
+  getPriceExtreme,
+  calculatePriceChange,
+  type PriceExtreme,
+} from "@/app/products/utils/price-comparison-utils";
 
-/**
- * Get maximum price for a product from Cijene API
- */
-export function getMaxPrice(product: ProductResponse): number {
-  if (maxPriceCache.has(product)) {
-    return maxPriceCache.get(product)!;
-  }
-  const prices = product.chains
-    .map((c) => parseFloat(c.max_price))
-    .filter((price) => Number.isFinite(price));
-  const max = prices.length > 0 ? Math.max(...prices) : 0;
-  const finalMax = Number.isFinite(max) ? max : 0;
-  maxPriceCache.set(product, finalMax);
-  return finalMax;
-}
-
-/**
- * Get average price for a product from Cijene API
- */
-export function getAveragePrice(product: ProductResponse): number {
-  if (avgPriceCache.has(product)) {
-    return avgPriceCache.get(product)!;
-  }
-  if (product.chains.length > 0) {
-    let sum = 0;
-    let count = 0;
-    for (const chain of product.chains) {
-      const parsed = parseFloat(chain.avg_price);
-      if (Number.isFinite(parsed)) {
-        sum += parsed;
-        count += 1;
-      }
-    }
-
-    const avg = sum / count;
-    if (Number.isFinite(avg)) {
-      avgPriceCache.set(product, avg);
-      return avg;
-    }
-  }
-  return 0;
-}
-
-/**
- * Parse price value from API string.
- */
-export function parsePrice(value: string): number | null {
-  const parsed = Number.parseFloat(value);
-
-  if (!Number.isFinite(parsed)) {
-    return null;
-  }
-
-  return parsed;
-}
-
-/**
- * Get cheapest chain and its min price from a chain list.
- */
-export function getCheapestChainByMinPrice(
-  chains: ChainProductResponse[],
-): { chain: ChainProductResponse; price: number } | null {
-  const pricedChains: Array<{ chain: ChainProductResponse; price: number }> =
-    [];
-
-  for (const chain of chains) {
-    const price = parsePrice(chain.min_price);
-
-    if (price !== null) {
-      pricedChains.push({ chain, price });
-    }
-  }
-
-  if (pricedChains.length === 0) {
-    return null;
-  }
-
-  return pricedChains.reduce((lowest, current) => {
-    if (current.price < lowest.price) {
-      return current;
-    }
-
-    return lowest;
-  });
-}
-
-/**
- * Get minimum price per unit for a product
- */
-export function getMinPricePerUnit(
-  product: ProductResponse,
-): number | undefined {
-  const quantity = Number(product.quantity);
-  if (Number.isFinite(quantity) && quantity > 0) {
-    return getMinPrice(product) / quantity;
-  }
-  return undefined;
-}
-
-/**
- * Get maximum price per unit for a product
- */
-export function getMaxPricePerUnit(
-  product: ProductResponse,
-): number | undefined {
-  const quantity = Number(product.quantity);
-  if (Number.isFinite(quantity) && quantity > 0) {
-    return getMaxPrice(product) / quantity;
-  }
-  return undefined;
-}
-
-/**
- * Get average price per unit for a product
- */
-export function getAveragePricePerUnit(
-  product: ProductResponse,
-): number | undefined {
-  const quantity = Number(product.quantity);
-  if (Number.isFinite(quantity) && quantity > 0) {
-    const avgPrice = getAveragePrice(product);
-    if (avgPrice !== undefined) {
-      return avgPrice / quantity;
-    }
-  }
-  return undefined;
-}
-
-export type PriceExtreme = "min" | "max" | null;
-
-/**
- * Classify a price against a range's overall min/max.
- * Returns null when the value is neither extreme, OR when min === max - a
- * uniform price has no cheapest/most-expensive distinction to color, so every
- * view renders it neutrally instead of disagreeing (red vs green).
- */
-export function getPriceExtreme(
-  value: number,
-  min: number,
-  max: number,
-): PriceExtreme {
-  if (![value, min, max].every(Number.isFinite)) {
-    return null;
-  }
-  if (min === max) {
-    return null;
-  }
-  if (value === min) {
-    return "min";
-  }
-  if (value === max) {
-    return "max";
-  }
-  return null;
-}
-
-/**
- * Calculate price change difference and percentage
- */
-export function calculatePriceChange(
-  currentPrice: number,
-  previousPrice: number,
-) {
-  const percentage = Math.abs(
-    ((currentPrice - previousPrice) / previousPrice) * 100,
-  );
-  const difference = Number((currentPrice - previousPrice).toFixed(2));
-
-  return {
-    percentage,
-    difference,
-  };
-}
+export { getMostFrequentCategory } from "@/app/products/utils/product-category-utils";

--- a/frontend/src/components/custom/header/components/header-nav-item.tsx
+++ b/frontend/src/components/custom/header/components/header-nav-item.tsx
@@ -61,7 +61,7 @@ export default function HeaderNavItem({
           {label}
 
           {item.badge && hasNotifications && (
-            <Badge size="count" className="absolute -top-3.5 -right-4">
+            <Badge size="count" className="absolute -top-2 -right-3.5">
               {notificationCount}
             </Badge>
           )}

--- a/frontend/src/components/custom/notifications/components/notification-item.tsx
+++ b/frontend/src/components/custom/notifications/components/notification-item.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { IWatchlistNotification } from "@/context/notifications-types";
+import StorePriceList from "@/components/custom/price/store-price-list";
 import { formatQuantity } from "@/utils/strings";
 
 interface INotificationItemProps {
@@ -39,17 +40,7 @@ export default function NotificationItem({
             )}
           </div>
 
-          <div className="space-y-0">
-            {notification.discountedStores.map((store) => (
-              <p
-                key={`${notification.id}-${store.chainName}`}
-                className="text-sm first:text-green-700"
-              >
-                {store.chainName} ~ {store.currentPrice.toFixed(2)}€
-                {` (-${store.discountAmount.toFixed(2)}€, ${Math.round(store.discountPercentage)}%)`}
-              </p>
-            ))}
-          </div>
+          <StorePriceList stores={notification.discountedStores} />
         </div>
       </div>
     </Link>

--- a/frontend/src/components/custom/notifications/notifications-dropdown.tsx
+++ b/frontend/src/components/custom/notifications/notifications-dropdown.tsx
@@ -64,7 +64,7 @@ export default function NotificationsDropdown({
           <BellRingIcon size={18} />
 
           {hasNotifications && (
-            <Badge size="count" className="absolute -top-2 -right-1">
+            <Badge size="count" className="absolute -top-1 -right-0.5">
               {notifications.length}
             </Badge>
           )}

--- a/frontend/src/components/custom/price/price-change-display.tsx
+++ b/frontend/src/components/custom/price/price-change-display.tsx
@@ -1,5 +1,6 @@
 import { ArrowBigDownDash, ArrowBigUpDash } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { priceDeltaColorClass } from "@/utils/price";
 
 interface IPriceChangeDisplayProps {
   priceChange: {
@@ -17,11 +18,7 @@ export default function PriceChangeDisplay({
     <h3
       className={cn(
         "text-right flex gap-2 flex-wrap items-center justify-end transition-all",
-        {
-          "text-red-700": priceChange.difference > 0,
-          "text-green-700": priceChange.difference < 0,
-          "text-gray-700": priceChange.difference === 0,
-        },
+        priceDeltaColorClass(priceChange.difference),
       )}
     >
       <span>

--- a/frontend/src/components/custom/price/price-change-display.tsx
+++ b/frontend/src/components/custom/price/price-change-display.tsx
@@ -5,7 +5,7 @@ import { priceDeltaColorClass } from "@/utils/price";
 interface IPriceChangeDisplayProps {
   priceChange: {
     difference: number;
-    percentage: number;
+    percentage: number | null;
   } | null;
 }
 
@@ -27,7 +27,9 @@ export default function PriceChangeDisplay({
         {priceChange.difference.toFixed(2)}€
       </span>
 
-      <span>({Math.round(Math.abs(priceChange.percentage))}%)</span>
+      {priceChange.percentage !== null && (
+        <span>({Math.round(Math.abs(priceChange.percentage))}%)</span>
+      )}
 
       {priceChange.difference !== 0 &&
         (priceChange.difference < 0 ? (

--- a/frontend/src/components/custom/price/store-price-list.tsx
+++ b/frontend/src/components/custom/price/store-price-list.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import type { INotificationStore } from "@/context/notifications-types";
 
 interface IStorePriceListProps {
@@ -8,7 +9,10 @@ export default function StorePriceList({ stores }: IStorePriceListProps) {
   return (
     <div className="space-y-0">
       {stores.map((store) => (
-        <p key={store.chainName} className="text-sm first:text-green-700">
+        <p
+          key={store.chainName}
+          className={cn("text-sm", store.meetsThreshold && "text-green-700")}
+        >
           {store.chainName} ~ {store.currentPrice.toFixed(2)}€
           {` (-${store.discountAmount.toFixed(2)}€, ${Math.round(store.discountPercentage)}%)`}
         </p>

--- a/frontend/src/components/custom/price/store-price-list.tsx
+++ b/frontend/src/components/custom/price/store-price-list.tsx
@@ -6,12 +6,20 @@ interface IStorePriceListProps {
 }
 
 export default function StorePriceList({ stores }: IStorePriceListProps) {
+  const bestPercentage = stores.length
+    ? Math.max(...stores.map((store) => Math.round(store.discountPercentage)))
+    : 0;
+
   return (
     <div className="space-y-0">
       {stores.map((store) => (
         <p
           key={store.chainName}
-          className={cn("text-sm", store.meetsThreshold && "text-green-700")}
+          className={cn(
+            "text-sm",
+            Math.round(store.discountPercentage) === bestPercentage &&
+              "text-green-700",
+          )}
         >
           {store.chainName} ~ {store.currentPrice.toFixed(2)}€
           {` (-${store.discountAmount.toFixed(2)}€, ${Math.round(store.discountPercentage)}%)`}

--- a/frontend/src/components/custom/price/store-price-list.tsx
+++ b/frontend/src/components/custom/price/store-price-list.tsx
@@ -18,7 +18,7 @@ export default function StorePriceList({ stores }: IStorePriceListProps) {
           className={cn(
             "text-sm",
             Math.round(store.discountPercentage) === bestPercentage &&
-              "text-green-700",
+              "text-primary",
           )}
         >
           {store.chainName} ~ {store.currentPrice.toFixed(2)}€

--- a/frontend/src/components/custom/price/store-price-list.tsx
+++ b/frontend/src/components/custom/price/store-price-list.tsx
@@ -1,0 +1,18 @@
+import type { INotificationStore } from "@/context/notifications-types";
+
+interface IStorePriceListProps {
+  stores: INotificationStore[];
+}
+
+export default function StorePriceList({ stores }: IStorePriceListProps) {
+  return (
+    <div className="space-y-0">
+      {stores.map((store) => (
+        <p key={store.chainName} className="text-sm first:text-green-700">
+          {store.chainName} ~ {store.currentPrice.toFixed(2)}€
+          {` (-${store.discountAmount.toFixed(2)}€, ${Math.round(store.discountPercentage)}%)`}
+        </p>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/custom/price/store-price-tooltip.tsx
+++ b/frontend/src/components/custom/price/store-price-tooltip.tsx
@@ -13,19 +13,21 @@ import type { INotificationStore } from "@/context/notifications-types";
 interface IStorePriceTooltipProps {
   stores: INotificationStore[];
   emptyLabel?: string;
+  side?: "top" | "right" | "bottom" | "left";
   children: ReactNode;
 }
 
 export default function StorePriceTooltip({
   stores,
   emptyLabel = "Nema sniženja",
+  side,
   children,
 }: IStorePriceTooltipProps) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>{children}</TooltipTrigger>
 
-      <TooltipContent variant="neutral" className="px-3 py-2">
+      <TooltipContent variant="neutral" side={side} className="px-3 py-2">
         {stores.length > 0 ? (
           <StorePriceList stores={stores} />
         ) : (

--- a/frontend/src/components/custom/price/store-price-tooltip.tsx
+++ b/frontend/src/components/custom/price/store-price-tooltip.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode } from "react";
+import type { ReactElement } from "react";
 
 import {
   Tooltip,
@@ -14,7 +14,7 @@ interface IStorePriceTooltipProps {
   stores: INotificationStore[];
   emptyLabel?: string;
   side?: "top" | "right" | "bottom" | "left";
-  children: ReactNode;
+  children: ReactElement;
 }
 
 export default function StorePriceTooltip({

--- a/frontend/src/components/custom/price/store-price-tooltip.tsx
+++ b/frontend/src/components/custom/price/store-price-tooltip.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { ReactNode } from "react";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import StorePriceList from "@/components/custom/price/store-price-list";
+import type { INotificationStore } from "@/context/notifications-types";
+
+interface IStorePriceTooltipProps {
+  stores: INotificationStore[];
+  emptyLabel?: string;
+  children: ReactNode;
+}
+
+export default function StorePriceTooltip({
+  stores,
+  emptyLabel = "Nema sniženja",
+  children,
+}: IStorePriceTooltipProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+
+      <TooltipContent variant="neutral" className="px-3 py-2">
+        {stores.length > 0 ? (
+          <StorePriceList stores={stores} />
+        ) : (
+          <p className="text-sm">{emptyLabel}</p>
+        )}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/frontend/src/components/custom/product/product-card.tsx
+++ b/frontend/src/components/custom/product/product-card.tsx
@@ -46,8 +46,8 @@ export default function ProductCard({
         className,
       )}
     >
-      <div className="flex flex-wrap items-center justify-between gap-3 px-3 py-2 @md:gap-4 @md:px-6 @md:py-4">
-        <div className="flex min-w-0 grow basis-48 items-center gap-4">
+      <div className="flex flex-col justify-between gap-3 px-3 py-2 @min-[320px]:flex-row @min-[320px]:items-center @md:gap-4 @md:px-6 @md:py-4">
+        <div className="flex min-w-0 flex-1 items-center gap-4">
           {imageUrl && (
             <Image
               src={imageUrl}
@@ -71,7 +71,7 @@ export default function ProductCard({
 
         {trailing && (
           <div
-            className="flex shrink-0 items-center gap-4"
+            className="flex shrink-0 items-center justify-between gap-4"
             onClick={stopCardNavigation}
           >
             {trailing}

--- a/frontend/src/components/custom/product/product-card.tsx
+++ b/frontend/src/components/custom/product/product-card.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { MouseEvent, ReactNode } from "react";
+import Image from "next/image";
+
+import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import ProductInfo from "@/components/custom/product/product-info";
+import { cn } from "@/lib/utils";
+
+interface IProductCardProps {
+  name: string | null;
+  brand?: string | null;
+  category: string | null;
+  quantity?: string | null;
+  imageUrl?: string | null;
+  onClick?: () => void;
+  isLoading?: boolean;
+  trailing?: ReactNode;
+  className?: string;
+}
+
+export default function ProductCard({
+  name,
+  brand,
+  category,
+  quantity,
+  imageUrl,
+  onClick,
+  isLoading = false,
+  trailing,
+  className,
+}: IProductCardProps) {
+  const displayName = name && quantity ? `${name} (${quantity})` : name;
+
+  function stopCardNavigation(event: MouseEvent) {
+    if (onClick) event.stopPropagation();
+  }
+
+  return (
+    <Card
+      onClick={onClick}
+      className={cn(
+        "@container shadow-sm hover:shadow-lg transition-shadow",
+        onClick && "cursor-pointer",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between gap-3 px-3 py-2 @md:gap-4 @md:px-6 @md:py-4">
+        <div className="flex min-w-0 flex-1 items-center gap-4">
+          {imageUrl && (
+            <Image
+              src={imageUrl}
+              alt={name ?? ""}
+              width={80}
+              height={80}
+              className="hidden @md:block size-16 @lg:size-20 shrink-0 rounded-lg object-contain"
+            />
+          )}
+
+          {isLoading ? (
+            <div className="min-w-0 flex-1 space-y-2">
+              <Skeleton className="h-3.5 w-24" />
+              <Skeleton className="h-5 w-48" />
+              <Skeleton className="h-3.5 w-32" />
+            </div>
+          ) : (
+            <ProductInfo name={displayName} brand={brand} category={category} />
+          )}
+        </div>
+
+        {trailing && (
+          <div
+            className="flex shrink-0 items-center gap-4"
+            onClick={stopCardNavigation}
+          >
+            {trailing}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/custom/product/product-card.tsx
+++ b/frontend/src/components/custom/product/product-card.tsx
@@ -17,8 +17,6 @@ interface IProductCardProps {
   onClick?: () => void;
   isLoading?: boolean;
   trailing?: ReactNode;
-  // Lets the trailing content drop below itself when the card runs out of room.
-  trailingWraps?: boolean;
   className?: string;
 }
 
@@ -31,7 +29,6 @@ export default function ProductCard({
   onClick,
   isLoading = false,
   trailing,
-  trailingWraps = false,
   className,
 }: IProductCardProps) {
   const displayName = name && quantity ? `${name} (${quantity})` : name;
@@ -49,8 +46,8 @@ export default function ProductCard({
         className,
       )}
     >
-      <div className="flex items-center justify-between gap-3 px-3 py-2 @md:gap-4 @md:px-6 @md:py-4">
-        <div className="flex min-w-0 flex-1 items-center gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 px-3 py-2 @md:gap-4 @md:px-6 @md:py-4">
+        <div className="flex min-w-0 grow basis-48 items-center gap-4">
           {imageUrl && (
             <Image
               src={imageUrl}
@@ -74,12 +71,7 @@ export default function ProductCard({
 
         {trailing && (
           <div
-            className={cn(
-              "flex items-center gap-4",
-              trailingWraps
-                ? "min-w-0 flex-wrap-reverse justify-end gap-y-2"
-                : "shrink-0",
-            )}
+            className="flex shrink-0 items-center gap-4"
             onClick={stopCardNavigation}
           >
             {trailing}

--- a/frontend/src/components/custom/product/product-card.tsx
+++ b/frontend/src/components/custom/product/product-card.tsx
@@ -17,6 +17,8 @@ interface IProductCardProps {
   onClick?: () => void;
   isLoading?: boolean;
   trailing?: ReactNode;
+  // Lets the trailing content drop below itself when the card runs out of room.
+  trailingWraps?: boolean;
   className?: string;
 }
 
@@ -29,6 +31,7 @@ export default function ProductCard({
   onClick,
   isLoading = false,
   trailing,
+  trailingWraps = false,
   className,
 }: IProductCardProps) {
   const displayName = name && quantity ? `${name} (${quantity})` : name;
@@ -71,7 +74,12 @@ export default function ProductCard({
 
         {trailing && (
           <div
-            className="flex shrink-0 items-center gap-4"
+            className={cn(
+              "flex items-center gap-4",
+              trailingWraps
+                ? "min-w-0 flex-wrap-reverse justify-end gap-y-2"
+                : "shrink-0",
+            )}
             onClick={stopCardNavigation}
           >
             {trailing}

--- a/frontend/src/components/custom/product/product-card.tsx
+++ b/frontend/src/components/custom/product/product-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MouseEvent, ReactNode } from "react";
+import { KeyboardEvent, MouseEvent, ReactNode } from "react";
 import Image from "next/image";
 
 import { Card } from "@/components/ui/card";
@@ -37,9 +37,21 @@ export default function ProductCard({
     if (onClick) event.stopPropagation();
   }
 
+  function handleCardKeyDown(event: KeyboardEvent) {
+    if (!onClick) return;
+
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onClick();
+    }
+  }
+
   return (
     <Card
       onClick={onClick}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={onClick ? handleCardKeyDown : undefined}
       className={cn(
         "@container shadow-sm hover:shadow-lg transition-shadow",
         onClick && "cursor-pointer",

--- a/frontend/src/components/custom/product/product-card.tsx
+++ b/frontend/src/components/custom/product/product-card.tsx
@@ -39,6 +39,8 @@ export default function ProductCard({
 
   function handleCardKeyDown(event: KeyboardEvent) {
     if (!onClick) return;
+    // Ignore keydowns bubbled from focusable controls inside the card.
+    if (event.target !== event.currentTarget) return;
 
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();

--- a/frontend/src/components/custom/product/product-info.tsx
+++ b/frontend/src/components/custom/product/product-info.tsx
@@ -14,16 +14,16 @@ const ProductInfo = memo(function ProductInfo({
   category,
 }: IProductInfoProps) {
   return (
-    <div className="flex-1">
+    <div className="min-w-0 flex-1">
       {category && (
-        <div className="text-xs sm:text-sm text-gray-500">{category}</div>
+        <div className="text-xs @md:text-sm text-gray-500">{category}</div>
       )}
 
-      <h3 className="font-bold text-sm sm:text-base text-pretty">
-        {name || "Unknown product name"}
+      <h3 className="font-bold text-sm @md:text-base text-pretty">
+        {name || "Nepoznat proizvod"}
       </h3>
 
-      {brand && <div className="text-xs sm:text-sm">{brand}</div>}
+      {brand && <div className="text-xs @md:text-sm">{brand}</div>}
     </div>
   );
 });

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -30,7 +30,7 @@ const buttonVariants = cva(
         infoSoft:
           "border border-blue-200 bg-blue-50 text-blue-700 hover:bg-blue-100 dark:border-blue-900 dark:bg-blue-950 dark:text-blue-300 dark:hover:bg-blue-900",
         outline:
-          "outline-2 -outline-offset-2 hover:outline-secondary hover:bg-green-50 hover:text-accent-foreground shadow-sm",
+          "outline-2 -outline-offset-2 bg-white hover:outline-secondary hover:bg-green-50 hover:text-accent-foreground shadow-sm",
         // Functional-only variants with no colour-scheme equivalent.
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80 shadow-xs",

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -20,6 +20,7 @@ const tooltipContentVariants = cva(
         warning: "bg-amber-200 text-amber-700",
         warningSoft:
           "bg-amber-50 text-amber-600 dark:bg-amber-950 dark:text-amber-300",
+        neutral: "bg-popover text-popover-foreground border shadow-md",
       },
     },
     defaultVariants: { variant: "primary" },
@@ -38,6 +39,7 @@ const tooltipArrowVariants = cva(
         warning: "bg-amber-200 fill-amber-200 text-amber-700",
         warningSoft:
           "bg-amber-50 fill-amber-50 text-amber-600 dark:bg-amber-950 dark:fill-amber-950 dark:text-amber-300",
+        neutral: "bg-popover fill-popover",
       },
     },
     defaultVariants: { variant: "primary" },

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -39,7 +39,7 @@ const tooltipArrowVariants = cva(
         warning: "bg-amber-200 fill-amber-200 text-amber-700",
         warningSoft:
           "bg-amber-50 fill-amber-50 text-amber-600 dark:bg-amber-950 dark:fill-amber-950 dark:text-amber-300",
-        neutral: "bg-popover fill-popover",
+        neutral: "bg-popover fill-popover border",
       },
     },
     defaultVariants: { variant: "primary" },

--- a/frontend/src/context/build-watchlist-notifications.ts
+++ b/frontend/src/context/build-watchlist-notifications.ts
@@ -70,7 +70,6 @@ export function buildWatchlistNotifications(
         currentPrice: store.currentPrice,
         discountAmount: store.discountAmount,
         discountPercentage: store.discountPercentage,
-        meetsThreshold: true,
       }))
       .sort((a, b) => {
         if (b.discountAmount !== a.discountAmount) {

--- a/frontend/src/context/build-watchlist-notifications.ts
+++ b/frontend/src/context/build-watchlist-notifications.ts
@@ -70,6 +70,7 @@ export function buildWatchlistNotifications(
         currentPrice: store.currentPrice,
         discountAmount: store.discountAmount,
         discountPercentage: store.discountPercentage,
+        meetsThreshold: true,
       }))
       .sort((a, b) => {
         if (b.discountAmount !== a.discountAmount) {

--- a/frontend/src/context/notifications-types.ts
+++ b/frontend/src/context/notifications-types.ts
@@ -3,7 +3,6 @@ export interface INotificationStore {
   currentPrice: number;
   discountAmount: number;
   discountPercentage: number;
-  meetsThreshold?: boolean;
 }
 
 export interface IWatchlistNotification {

--- a/frontend/src/context/notifications-types.ts
+++ b/frontend/src/context/notifications-types.ts
@@ -3,6 +3,7 @@ export interface INotificationStore {
   currentPrice: number;
   discountAmount: number;
   discountPercentage: number;
+  meetsThreshold?: boolean;
 }
 
 export interface IWatchlistNotification {

--- a/frontend/src/hooks/use-product-navigation.ts
+++ b/frontend/src/hooks/use-product-navigation.ts
@@ -15,7 +15,7 @@ export default function useProductNavigation() {
       queryClient.setQueryData(productByEanQueryKey(ean), product);
     }
 
-    router.push(`/products/${ean}`);
+    router.push(`/products/${encodeURIComponent(ean)}`);
   }
 
   return navigateToProduct;

--- a/frontend/src/hooks/use-product-navigation.ts
+++ b/frontend/src/hooks/use-product-navigation.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { productByEanQueryKey } from "@/lib/cijene-api";
+import { ProductResponse } from "@/lib/cijene-api/schemas";
+
+export default function useProductNavigation() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  function navigateToProduct(ean: string, product?: ProductResponse) {
+    if (product) {
+      queryClient.setQueryData(productByEanQueryKey(ean), product);
+    }
+
+    router.push(`/products/${ean}`);
+  }
+
+  return navigateToProduct;
+}

--- a/frontend/src/utils/price.ts
+++ b/frontend/src/utils/price.ts
@@ -1,0 +1,16 @@
+import { cn } from "@/lib/utils";
+
+export function formatPriceDelta(
+  difference: number,
+  percentage: number,
+): string {
+  return `${difference > 0 ? "+" : ""}${difference.toFixed(2)}€ (${Math.round(Math.abs(percentage))}%)`;
+}
+
+export function priceDeltaColorClass(difference: number | null): string {
+  return cn({
+    "text-red-700": (difference ?? 0) > 0,
+    "text-green-700": (difference ?? 0) < 0,
+    "text-gray-700": (difference ?? 0) === 0,
+  });
+}


### PR DESCRIPTION
Unifies the products-list card and the watchlist item onto one `ProductCard` shell, and improves the watchlist per the "Unify products card and improve watchlist" board task.

## Shared ProductCard
- New `components/custom/product/product-card.tsx` (+ moved `product-info.tsx`) owns the card shell, the identity block (category / name / brand, and a wired image slot), loading skeletons, and a `trailing` slot for the differing right-hand content.
- Both cards are whole-card clickable via the new `useProductNavigation` hook (seeds the React Query cache, then navigates); interactive trailing controls stop propagation.
- Layout is driven by **container queries** (`@container` / `@md`) instead of viewport `sm:`, so a card in a narrow grid cell renders compact regardless of viewport, and the trailing (prices on products; stores + badges + remove on watchlist) wraps to a line **below** the info once the card is under ~400px, staying inline above that.

## Watchlist improvements
- Threshold badges show a pencil edit affordance to the right of the value (the badge already opens the edit modal); the badges stack under the remove button on mobile and sit inline-left of it on `sm+`.
- Store-price hover tooltip on both discount rows, reusing the notification's store~price line via new `StorePriceList` / `StorePriceTooltip` and a neutral tooltip variant.
- Every store that beats a watch threshold is marked green (not just the cheapest); the all-stores tooltip opens downward so it no longer covers the preferred-stores row above it.

## Housekeeping
- Split the 230-line `product-utils.ts` into concern files behind a barrel (matching the existing `watchlist-utils.ts` pattern); extracted `useWatchlistRemoval`, `WatchlistThresholdBadges`, `WatchlistDiscountRow` and discount-display utils to keep files within the 50-100 line guideline.

## Notes
- No image field exists in the DTO yet; the image slot renders nothing until a URL is available.
- The ~400px wrap point is a `basis-48` floor on the info block (content-dependent, tunable); a container-query `@max-[400px]:` cutoff is available if an exact threshold is preferred.

## Verification
- `pnpm exec prettier --write` + `pnpm exec tsc --noEmit` clean on all touched files.
- Manual: products list unchanged behaviorally; watchlist shows category, whole-card navigation, pencil badges, store tooltips, green matching stores, and the trailing wrapping below the name on narrow cards.