### PR TITLE
fix(header): Mobile header gap and notification badge polish

### DIFF
--- a/frontend/src/components/custom/header/components/header-nav-item.tsx
+++ b/frontend/src/components/custom/header/components/header-nav-item.tsx
@@ -61,7 +61,7 @@ export default function HeaderNavItem({
           {label}
 
           {item.badge && hasNotifications && (
-            <Badge size="count" className="absolute -top-3.5 -right-4">
+            <Badge size="count" className="absolute -top-2 -right-4">
               {notificationCount}
             </Badge>
           )}

--- a/frontend/src/components/custom/header/header.tsx
+++ b/frontend/src/components/custom/header/header.tsx
@@ -20,7 +20,7 @@ export default function Header() {
                 "bg-background/50 max-w-5xl rounded-2xl border backdrop-blur-sm px-4",
             )}
           >
-            <div className="flex items-center justify-between gap-6 flex-wrap py-2 sm:py-4">
+            <div className="flex items-center justify-between gap-2 sm:gap-6 flex-wrap py-2 sm:py-4">
               <HeaderBrand />
 
               <HeaderNav />

--- a/frontend/src/components/custom/notifications/notifications-dropdown.tsx
+++ b/frontend/src/components/custom/notifications/notifications-dropdown.tsx
@@ -64,7 +64,7 @@ export default function NotificationsDropdown({
           <BellRingIcon size={18} />
 
           {hasNotifications && (
-            <Badge size="count" className="absolute -top-2 -right-1">
+            <Badge size="count" className="absolute -top-0.5 -right-1">
               {notifications.length}
             </Badge>
           )}


### PR DESCRIPTION
## Walkthrough

Three small header/nav polish tweaks for mobile: tightening the header row gap so the user section wraps later, and nudging the two notification count badges down over their icons.

## Changes

| File | Summary |
| --- | --- |
| `frontend/src/components/custom/header/header.tsx` | Header row gap `gap-6` -> `gap-2 sm:gap-6`. On small screens the 24px gap pushed the brand/search/user items apart and wrapped the notifications + user menu onto a new line too early; an 8px gap below `sm` keeps them on one row longer. |
| `frontend/src/components/custom/notifications/notifications-dropdown.tsx` | Notification bell count badge nudged down to `-top-0.5 -right-1`. |
| `frontend/src/components/custom/header/components/header-nav-item.tsx` | Praćenje nav count badge nudged down to `-top-2 -right-4`. |

## Note on the badge conflict

`dev` had a separate "fix location notification badges" change that set the two count badges to different positions. Per decision, this PR keeps the badge positions dialed in on this branch (bell `-top-0.5`, nav `-top-2 -right-4`), overriding dev's. `dev` was merged into the branch to resolve the overlap, so the PR merges cleanly.

## Estimated code review effort

🟢 1 (Trivial) | ~5 minutes. Three className-only tweaks; no logic or type surface.