### PR TITLE
Dev -> main: header mobile gap and badge polish

### DIFF
--- a/frontend/src/components/custom/header/components/header-nav-item.tsx
+++ b/frontend/src/components/custom/header/components/header-nav-item.tsx
@@ -61,7 +61,7 @@ export default function HeaderNavItem({
           {label}
 
           {item.badge && hasNotifications && (
-            <Badge size="count" className="absolute -top-3.5 -right-4">
+            <Badge size="count" className="absolute -top-2 -right-4">
               {notificationCount}
             </Badge>
           )}

--- a/frontend/src/components/custom/header/header.tsx
+++ b/frontend/src/components/custom/header/header.tsx
@@ -20,7 +20,7 @@ export default function Header() {
                 "bg-background/50 max-w-5xl rounded-2xl border backdrop-blur-sm px-4",
             )}
           >
-            <div className="flex items-center justify-between gap-6 flex-wrap py-2 sm:py-4">
+            <div className="flex items-center justify-between gap-2 sm:gap-6 flex-wrap py-2 sm:py-4">
               <HeaderBrand />
 
               <HeaderNav />

--- a/frontend/src/components/custom/notifications/notifications-dropdown.tsx
+++ b/frontend/src/components/custom/notifications/notifications-dropdown.tsx
@@ -64,7 +64,7 @@ export default function NotificationsDropdown({
           <BellRingIcon size={18} />
 
           {hasNotifications && (
-            <Badge size="count" className="absolute -top-2 -right-1">
+            <Badge size="count" className="absolute -top-0.5 -right-1">
               {notifications.length}
             </Badge>
           )}


### PR DESCRIPTION
## Walkthrough

Promotes `dev` to `main`. This delta contains only the header mobile polish from #97: a tighter header row gap on small screens so the user section wraps later, plus two notification count-badge position nudges.

## Changes

| File | Summary |
| --- | --- |
| `frontend/src/components/custom/header/header.tsx` | Header row gap `gap-6` -> `gap-2 sm:gap-6`; below `sm` the notifications + user menu stay on one row longer instead of wrapping early. |
| `frontend/src/components/custom/notifications/notifications-dropdown.tsx` | Bell count badge nudged to `-top-0.5 -right-1`. |
| `frontend/src/components/custom/header/components/header-nav-item.tsx` | Praćenje nav count badge nudged to `-top-2 -right-4`. |

## Estimated code review effort

🟢 **1 (Trivial)** | ~5 minutes. Three className-only changes; no logic or type surface.

## Possibly related PRs

- **#97** - fix(header): Mobile header gap and notification badge polish (the entire content of this promotion).