### PR TITLE
feat(search): Retry product search with fuzzy matching when exact returns too few

### DIFF
--- a/frontend/src/app/api/cijene/products/route.ts
+++ b/frontend/src/app/api/cijene/products/route.ts
@@ -1,13 +1,12 @@
 import { NextRequest } from "next/server";
 import { z } from "zod";
-import { cijeneApiV1Client } from "@/lib/cijene-api/client";
 import {
   productSearchResponseSchema,
   searchProductsParamsSchema,
 } from "@/lib/cijene-api/schemas";
+import { searchProductsWithFuzzyFallback } from "@/lib/cijene-api/utils/product-search-fallback";
 import { createApiError } from "@/lib/cijene-api/utils/response-utils";
 import { withCijeneRoute } from "@/lib/cijene-api/utils/with-cijene-route";
-import { buildQueryString } from "@/utils/generic";
 
 function parseBooleanParam(value: string | null): boolean | undefined {
   if (value === "true") return true;
@@ -35,9 +34,7 @@ export async function GET(request: NextRequest) {
     });
   }
 
-  const queryString = buildQueryString(parsed.data);
-
   return withCijeneRoute("products", productSearchResponseSchema, () =>
-    cijeneApiV1Client.get(`/products?${queryString}`),
+    searchProductsWithFuzzyFallback(parsed.data),
   );
 }

--- a/frontend/src/lib/cijene-api/queries.ts
+++ b/frontend/src/lib/cijene-api/queries.ts
@@ -14,13 +14,16 @@ import {
   listChainsResponseSchema,
   listStoresResponseSchema,
   productResponseSchema,
+  productSearchResponseSchema,
   storePricesResponseSchema,
   chainStatsResponseSchema,
   healthCheckResponseSchema,
   getProductParamsSchema,
+  searchProductsParamsSchema,
   searchStoresParamsSchema,
   getPricesParamsSchema,
 } from "@/lib/cijene-api/schemas";
+import { buildQueryString } from "@/utils/generic";
 
 export async function listChains(): Promise<ListChainsResponse> {
   const response = await axios.get("/api/cijene/chains");
@@ -68,19 +71,12 @@ export async function getProductByEan(
 export async function getProductByName(
   params: SearchProductsParams,
 ): Promise<ProductSearchResponse> {
-  const queryParams = new URLSearchParams();
-  queryParams.append("q", params.q);
-  if (params.date) queryParams.append("date", params.date);
-  if (params.chains) queryParams.append("chains", params.chains);
-  if (params.fuzzy !== undefined)
-    queryParams.append("fuzzy", params.fuzzy.toString());
-  if (params.limit !== undefined)
-    queryParams.append("limit", params.limit.toString());
+  const validatedParams = searchProductsParamsSchema.parse(params);
 
   const response = await axios.get(
-    `/api/cijene/products?${queryParams.toString()}`,
+    `/api/cijene/products?${buildQueryString(validatedParams)}`,
   );
-  return response.data;
+  return productSearchResponseSchema.parse(response.data);
 }
 
 export async function getPrices(

--- a/frontend/src/lib/cijene-api/utils/product-search-fallback.ts
+++ b/frontend/src/lib/cijene-api/utils/product-search-fallback.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+import { cijeneApiV1Client } from "@/lib/cijene-api/client";
+import {
+  ProductResponse,
+  SearchProductsParams,
+  productSearchResponseSchema,
+} from "@/lib/cijene-api/schemas";
+import { buildQueryString } from "@/utils/generic";
+
+/**
+ * Fuzzy ranks by whole-string trigram distance, so it promotes short unrelated
+ * rows and loses to exact search on every well-spelled query. It only wins where
+ * exact returns almost nothing: https://github.com/senko/cijene-api/issues/65
+ */
+const FUZZY_FALLBACK_THRESHOLD = 10;
+
+/** Upstream's own default when `limit` is omitted. */
+const UPSTREAM_DEFAULT_LIMIT = 20;
+
+const searchResultCountSchema = z.object({ products: z.array(z.unknown()) });
+
+function fetchProducts(params: SearchProductsParams) {
+  return cijeneApiV1Client.get(`/products?${buildQueryString(params)}`);
+}
+
+function countProducts(data: unknown): number | null {
+  const parsed = searchResultCountSchema.safeParse(data);
+
+  return parsed.success ? parsed.data.products.length : null;
+}
+
+function mergeByEan(
+  exact: ProductResponse[],
+  fuzzy: ProductResponse[],
+  limit: number,
+): ProductResponse[] {
+  const alreadyMatched = new Set(exact.map((product) => product.ean));
+
+  return [
+    ...exact,
+    ...fuzzy.filter((product) => !alreadyMatched.has(product.ean)),
+  ].slice(0, limit);
+}
+
+/**
+ * Searches exactly first and tops the result up with fuzzy matches when the
+ * exact pass comes back nearly empty, so a typo still finds something without
+ * costing ranking quality on the queries that already work.
+ */
+export async function searchProductsWithFuzzyFallback(
+  params: SearchProductsParams,
+): Promise<{ data: unknown }> {
+  if (params.fuzzy) return fetchProducts(params);
+
+  const exact = await fetchProducts({ ...params, fuzzy: false });
+  const exactCount = countProducts(exact.data);
+
+  if (exactCount === null || exactCount >= FUZZY_FALLBACK_THRESHOLD) {
+    return exact;
+  }
+
+  const fuzzy = await fetchProducts({ ...params, fuzzy: true }).catch(
+    () => null,
+  );
+
+  const exactParsed = productSearchResponseSchema.safeParse(exact.data);
+  const fuzzyParsed = productSearchResponseSchema.safeParse(fuzzy?.data);
+
+  if (!exactParsed.success || !fuzzyParsed.success) return exact;
+
+  return {
+    data: {
+      products: mergeByEan(
+        exactParsed.data.products,
+        fuzzyParsed.data.products,
+        params.limit ?? UPSTREAM_DEFAULT_LIMIT,
+      ),
+    },
+  };
+}


### PR DESCRIPTION
Retries product search with fuzzy matching when the exact pass returns almost nothing, and validates the search params and response at the client boundary.

## Why

Upstream `cijene-api` shipped three search fixes on 2026-07-24 ([f590d8be](https://github.com/senko/cijene-api/commit/f590d8be), [373b5493](https://github.com/senko/cijene-api/commit/373b5493)): exact search is now diacritic-insensitive, matches brand, uses the trigram index, applies the chain filter before the limit, and excludes products with no price on the effective date.

That fixed the exact path but not the fuzzy one. Benchmarking 30 Croatian grocery queries in both modes against prod:

|                        | well-spelled (19) | misspelled or bad spacing (11) |
| ---------------------- | ----------------- | ------------------------------ |
| P@10 `fuzzy=false`     | **0.99**          | 0.28                           |
| P@10 `fuzzy=true`      | 0.95              | **0.60**                       |
| zero results, exact    | 0                 | 6                              |
| zero results, fuzzy    | 0                 | 2                              |

Fuzzy ranks by whole-string trigram distance, which is length-normalised, so it promotes short unrelated rows. `q=mlijeko` with fuzzy on returns milk **jugs** in the top two slots; `q=dukat` returns coffee filters. It only adds value where exact returns almost nothing. So it earns a retry, not a place in the default query.

Details and the root-cause analysis are in [senko/cijene-api#65](https://github.com/senko/cijene-api/issues/65).

## What changed

- **`lib/cijene-api/utils/product-search-fallback.ts`** (new): searches exact, and if fewer than 10 products come back, retries with `fuzzy=true` and merges. Exact hits keep the leading slots, duplicates drop by EAN, the result is capped at the requested limit. An explicit `fuzzy=true` from the caller skips the two-step. A failed or unparseable retry returns the exact results rather than failing the search.
- **`app/api/cijene/products/route.ts`**: delegates to the new util. Query-string building moved with it; `withCijeneRoute` stays the single validation point.
- **`lib/cijene-api/queries.ts`**: `getProductByName` now parses params with `searchProductsParamsSchema` and the response with `productSearchResponseSchema`, matching every sibling function in the file. Closes #47.

The retry runs server-side in the route handler, so the browser still makes one request.

## Verification

Through the running dev server:

```
mlijeko    -> 100   (one upstream call, no retry)
cocacola   ->  53   (was 0)
jamnca     ->   4   (was 0)
koka kola  ->   0   (both passes empty, no crash)
```

Browser checks on `/products`:

- `?q=cocacola` renders 53 real Coca-Cola products with populated filter dropdowns. Was empty.
- `?q=mlijeko` unchanged at `(100+)`, top 10 all real milk, no `vrč za mlijeko` anywhere on the page.
- `?q=mlijeko&chain=konzum` gives `(76+)`, confirming chain filtering still runs client-side.

Module-level harness against the live API confirms the retry fires only below the threshold, exact-first ordering holds, EAN dedupe works, and the limit is respected on merge.

`prettier`, `tsc --noEmit` and `eslint` clean after rebasing onto current `dev` (only the 15 known pre-existing `PageProps` / `RouteContext` typegen errors, which disappear when `.next` is present).

## Not in this PR

Pushing the `chains` filter server-side. Upstream's `chains` param is both a selector and a projection: it also strips every other chain's prices out of each returned product, which would stop a chain-filtered view from showing that the same product is cheaper elsewhere. Filed as [senko/cijene-api#108](https://github.com/senko/cijene-api/issues/108); the frontend stays on client-side chain filtering until that is answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
