### PR TITLE
fix(seo): Make coming-soon nav items crawlable and keep the sidebar in prerendered HTML

### DIFF
--- a/frontend/src/components/custom/sidebar/app-sidebar.tsx
+++ b/frontend/src/components/custom/sidebar/app-sidebar.tsx
@@ -19,6 +19,7 @@ import InstallSidebarBanner from "@/components/custom/pwa/install-sidebar-banner
 import SidebarUser from "@/components/custom/sidebar/sidebar-user";
 import SidebarMainNav from "@/components/custom/sidebar/sidebar-main-nav";
 import SidebarProductNav from "@/components/custom/sidebar/sidebar-product-nav";
+import SidebarProductNavSkeleton from "@/components/custom/sidebar/sidebar-product-nav-skeleton";
 import SidebarSupportNav from "@/components/custom/sidebar/sidebar-support-nav";
 import ScrollFade from "@/components/custom/common/scroll-fade";
 import SearchBar from "@/components/custom/search/search-bar";
@@ -82,7 +83,11 @@ export default function AppSidebar() {
         >
           <SidebarMainNav />
 
-          <SidebarProductNav />
+          {/* Reads the URL, so this boundary keeps it from taking the whole
+              sidebar out of the prerendered HTML. */}
+          <Suspense fallback={<SidebarProductNavSkeleton />}>
+            <SidebarProductNav />
+          </Suspense>
 
           <SidebarSupportNav />
         </SidebarContent>

--- a/frontend/src/components/custom/sidebar/sidebar-nav-item.tsx
+++ b/frontend/src/components/custom/sidebar/sidebar-nav-item.tsx
@@ -1,13 +1,18 @@
 "use client";
 
 import Link from "next/link";
+import type { MouseEvent } from "react";
 import { SidebarMenuBadge, SidebarMenuButton } from "@/components/ui/sidebar";
 import { cn } from "@/lib/utils";
-import type { INavigationItem } from "@/constants/navigation";
+import { PLACEHOLDER_HREF, type INavigationItem } from "@/constants/navigation";
 
 // Opts out of the peer rules that would recolour badge text on hover or active.
 const BADGE_CLASS =
   "bg-primary text-primary-foreground peer-hover/menu-button:text-primary-foreground peer-data-[active=true]/menu-button:text-primary-foreground";
+
+function preventNavigation(event: MouseEvent<HTMLAnchorElement>) {
+  event.preventDefault();
+}
 
 interface ISidebarNavItemProps {
   item: INavigationItem;
@@ -33,18 +38,35 @@ export default function SidebarNavItem({
   // Badges are absolute, so the label needs room to truncate against.
   const labelSpace = showComingSoon ? "pr-16" : showCount ? "pr-8" : undefined;
 
+  // A locked item stays an anchor so crawlers still reach the page behind it.
+  const isDeadEnd = isLocked && item.href === PLACEHOLDER_HREF;
+
+  const label = (
+    <>
+      <Icon />
+      <span>{item.label}</span>
+    </>
+  );
+
   return (
     <>
-      {isLocked ? (
+      {isDeadEnd ? (
         <SidebarMenuButton type="button" disabled className={labelSpace}>
-          <Icon />
-          <span>{item.label}</span>
+          {label}
         </SidebarMenuButton>
       ) : (
-        <SidebarMenuButton asChild isActive={isActive} className={labelSpace}>
-          <Link href={item.href}>
-            <Icon />
-            <span>{item.label}</span>
+        <SidebarMenuButton
+          asChild
+          isActive={!isLocked && isActive}
+          className={labelSpace}
+        >
+          <Link
+            href={item.href}
+            aria-disabled={isLocked ? true : undefined}
+            tabIndex={isLocked ? -1 : undefined}
+            onClick={isLocked ? preventNavigation : undefined}
+          >
+            {label}
           </Link>
         </SidebarMenuButton>
       )}

--- a/frontend/src/components/custom/sidebar/sidebar-product-nav-skeleton.tsx
+++ b/frontend/src/components/custom/sidebar/sidebar-product-nav-skeleton.tsx
@@ -1,0 +1,43 @@
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubItem,
+} from "@/components/ui/sidebar";
+import { Skeleton } from "@/components/ui/skeleton";
+import { productNavItems } from "@/constants/navigation";
+
+/**
+ * Stands in for the product nav while it waits on the URL, which it cannot read
+ * during a static prerender. Mirrors the real row heights so nothing shifts.
+ */
+export default function SidebarProductNavSkeleton() {
+  return (
+    <SidebarGroup className="py-1">
+      <SidebarGroupLabel>Istraži</SidebarGroupLabel>
+
+      <SidebarGroupContent>
+        <SidebarMenu className="gap-0">
+          {productNavItems.map((item) => (
+            <SidebarMenuItem key={item.id}>
+              <Skeleton className="h-8 w-full" />
+
+              {item.children?.length ? (
+                <SidebarMenuSub className="gap-0">
+                  {item.children.map((child) => (
+                    <SidebarMenuSubItem key={child.id}>
+                      <Skeleton className="h-7 w-full" />
+                    </SidebarMenuSubItem>
+                  ))}
+                </SidebarMenuSub>
+              ) : null}
+            </SidebarMenuItem>
+          ))}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}

--- a/frontend/src/components/custom/sidebar/sidebar-product-nav.tsx
+++ b/frontend/src/components/custom/sidebar/sidebar-product-nav.tsx
@@ -13,7 +13,11 @@ import {
 import SidebarNavItem from "@/components/custom/sidebar/sidebar-nav-item";
 import SidebarFilterMenu from "@/components/custom/sidebar/sidebar-filter-menu";
 import { useSidebarFilterOptions } from "@/hooks/use-sidebar-filter-options";
-import { productNavItems, type INavigationItem } from "@/constants/navigation";
+import {
+  productNavItems,
+  PLACEHOLDER_HREF,
+  type INavigationItem,
+} from "@/constants/navigation";
 import { useUser } from "@/context/user-context";
 import { isAdmin } from "@/lib/api/schemas/auth-user";
 import { readListParam } from "@/utils/generic";
@@ -39,7 +43,7 @@ export default function SidebarProductNav() {
       return isOnProducts && searchParams.get("discounted") === "true";
     }
 
-    return item.href !== "#" && fullPath.startsWith(item.href);
+    return item.href !== PLACEHOLDER_HREF && fullPath.startsWith(item.href);
   }
 
   function renderFilterMenu(child: INavigationItem) {

--- a/frontend/src/constants/navigation.ts
+++ b/frontend/src/constants/navigation.ts
@@ -16,6 +16,9 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
+/** Destination for items whose page does not exist yet. */
+export const PLACEHOLDER_HREF = "#";
+
 export interface INavigationItem {
   id: string;
   href: string;
@@ -124,7 +127,7 @@ export const productNavItems: INavigationItem[] = [
     children: [
       {
         id: "stores",
-        href: "#",
+        href: PLACEHOLDER_HREF,
         label: "Trgovine",
         icon: Store,
 
@@ -134,7 +137,7 @@ export const productNavItems: INavigationItem[] = [
       },
       {
         id: "locations",
-        href: "#",
+        href: PLACEHOLDER_HREF,
         label: "Lokacije",
         icon: MapPin,
 
@@ -177,7 +180,7 @@ export const supportNavItems: INavigationItem[] = [
   },
   {
     id: "bug-report",
-    href: "#",
+    href: PLACEHOLDER_HREF,
     label: "Prijavi grešku",
     icon: Bug,
     comingSoon: true,


### PR DESCRIPTION
Makes the coming-soon nav destinations crawlable, and stops the sidebar dropping out of statically prerendered HTML.

## Why

An SEO audit of production turned up two independent problems.

**1. The sidebar was missing entirely from prerendered HTML.** `https://disscount.me/` shipped this:

```html
<aside><!--$!--><template data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING"></template><!--/$--></aside>
```

`sidebar-product-nav.tsx` and `sidebar-filter-menu.tsx` call `useSearchParams()`. The nearest Suspense boundary was `app/layout.tsx` with `fallback={null}`, so at prerender time the whole sidebar (search bar, all three nav groups, user footer) collapsed to nothing.

| sidebar in HTML | routes |
| --- | --- |
| no (prerendered) | `/`, `/statistics`, `/privacy-policy`, `/terms-of-service`, `/data-deletion`, `/updates/[slug]` |
| yes (dynamic) | `/products`, `/updates`, `/suggestions`, `/map` |

**2. Nothing worth crawling was a link.** Even where the sidebar did render, it emitted four hrefs: `/`, `?modal=contact`, `/shopping-lists`, `/watchlist`. The last two are `Disallow`ed in robots.txt. Ten items rendered as `<SidebarMenuButton type="button" disabled>`, which has no href.

The result was orphaned pages: `sitemap.ts` advertises `/updates`, `/map`, `/statistics` and `/suggestions`, and nothing anywhere linked to them. The sidebar disabled them, `header-nav.tsx` only shows `showInHeader: true` items, and the footer carries just the logo, GitHub and LinkedIn.

## What changed

- **`sidebar-nav-item.tsx`**: a locked item now renders its `<Link>` with the real href, plus `aria-disabled`, `tabIndex={-1}` and an `onClick` guard. The plain disabled `<button>` is kept only for items with no page behind them (currently just `Prijavi grešku`).
- **`constants/navigation.ts`**: adds `PLACEHOLDER_HREF` so the "no page yet" check is not a `"#"` magic string repeated across files.
- **`app-sidebar.tsx`** and new **`sidebar-product-nav-skeleton.tsx`**: `SidebarProductNav` gets its own Suspense boundary with a skeleton that mirrors the real row heights, confining the bailout to the Istraži group. This follows the `SearchBar` / `SearchBarSkeleton` pattern already used a few lines above it.

**Access is unchanged.** `isLocked` still decides who can navigate, coming-soon badges all stay, and no page files were touched. This is preparation, not a launch. Admins keep clicking through exactly as before.

No new CSS: `sidebarMenuButtonVariants` in `components/ui/sidebar.tsx` already carries `aria-disabled:pointer-events-none aria-disabled:opacity-50`.

## Verification

Every sidebar row against the dev server, parsed out of the served HTML:

```
A              /shopping-lists            Popisi za kupnju
A              /watchlist                 Praćeni proizvodi
A      LOCKED  /digital-cards             Digitalne kartice
A      LOCKED  /spending                  Potrošnja
A      LOCKED  /suggestions               Ideje i prijedlozi
BUTTON LOCKED  (no href)                  Prijavi grešku
A              ?modal=contact             Kontakt
A      LOCKED  /products?discounted=true  Popusti
A      LOCKED  /map                       Karta
A      LOCKED  /statistics                Statistika
A      LOCKED  /updates                   Novosti
```

Computed styles in the browser confirm the locked rows are inert:

```
/statistics   aria-disabled=true  tabIndex=-1  pointer-events=none  opacity=0.5
/watchlist    aria-disabled=-     tabIndex=0   pointer-events=auto  opacity=1
```

A programmatic `.click()` on a locked anchor (the screen-reader path that `pointer-events` alone would not block) leaves the path unchanged, confirming the `onClick` guard.

`prettier --check`, `tsc --noEmit` and `eslint` are clean.

## Not verifiable before deploy

The bailout only happens in a production build, so problem 1 cannot be reproduced against a dev server. After deploy, on the dev environment:

```
curl -s <dev-url>/ | grep -c BAILOUT_TO_CLIENT_SIDE_RENDERING   # expect 0, is 1 today
curl -s <dev-url>/ | grep -c 'data-slot="sidebar"'              # expect 1, is 0 today
```

## Known limit

`/map`, `/statistics` and `/updates` live inside `SidebarProductNav`, so they stay client-filled on statically prerendered routes. They are crawlable on the dynamic routes. `/suggestions` sits in `SidebarSupportNav` and will be server-rendered everywhere. Footer nav links would have closed the remaining gap and also de-orphaned the legal pages; that was considered and deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
