### PR TITLE
fix(search): Apply the pre-production review findings for dev to main

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "license": "BUSL-1.1",
+  "packageManager": "pnpm@11.9.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build --webpack",

--- a/frontend/src/app/products/hooks/use-infinite-products.ts
+++ b/frontend/src/app/products/hooks/use-infinite-products.ts
@@ -43,7 +43,6 @@ export default function useInfiniteProducts(
   // One unfiltered request, filtered client-side, so facet counts match results.
   const { data, isLoading, error } = useGetProductByName({
     q,
-    fuzzy: false,
     limit: PRODUCT_SEARCH_LIMIT, // Raising this needs paging upstream: >100 is a 422.
   });
 

--- a/frontend/src/app/products/hooks/use-product-facets.ts
+++ b/frontend/src/app/products/hooks/use-product-facets.ts
@@ -76,7 +76,6 @@ export default function useProductFacets(
   // Same request as the results list, so both derive from one cache entry.
   const { data: facetData } = useGetProductByName({
     q: query,
-    fuzzy: false,
     limit: PRODUCT_SEARCH_LIMIT,
   });
 

--- a/frontend/src/constants/products.ts
+++ b/frontend/src/constants/products.ts
@@ -4,6 +4,5 @@
 // matches (issue #93). Going beyond that needs upstream search-layer support.
 export const PRODUCT_SEARCH_LIMIT = 100;
 
-// The page size upstream applies when a request omits `limit`. The fuzzy
-// fallback needs it to cap merged results the way an exact-only call would.
+// Upstream's own default for GET /v1/products when `limit` is omitted.
 export const UPSTREAM_DEFAULT_SEARCH_LIMIT = 20;

--- a/frontend/src/constants/products.ts
+++ b/frontend/src/constants/products.ts
@@ -3,3 +3,7 @@
 // total count, or facet aggregation, so facet counts cover at most the first 100
 // matches (issue #93). Going beyond that needs upstream search-layer support.
 export const PRODUCT_SEARCH_LIMIT = 100;
+
+// The page size upstream applies when a request omits `limit`. The fuzzy
+// fallback needs it to cap merged results the way an exact-only call would.
+export const UPSTREAM_DEFAULT_SEARCH_LIMIT = 20;

--- a/frontend/src/lib/auth/token.ts
+++ b/frontend/src/lib/auth/token.ts
@@ -1,9 +1,21 @@
+import * as Sentry from "@sentry/nextjs";
+
 import { authClient } from "@/lib/auth/client";
 
+const SERVER_ERROR_STATUS = 500;
+
 export default async function fetchAuthToken(): Promise<string | null> {
-  const { data } = await authClient.$fetch<{ token: string }>("/token", {
+  const { data, error } = await authClient.$fetch<{ token: string }>("/token", {
     method: "GET",
   });
+
+  if (error && error.status >= SERVER_ERROR_STATUS) {
+    Sentry.captureException(
+      new Error(
+        `Auth token request failed: ${error.status} ${error.statusText}`,
+      ),
+    );
+  }
 
   return data?.token ?? null;
 }

--- a/frontend/src/lib/cijene-api/utils/product-search-fallback.ts
+++ b/frontend/src/lib/cijene-api/utils/product-search-fallback.ts
@@ -27,6 +27,10 @@ function countProducts(data: unknown): number | null {
   return parsed.success ? parsed.data.products.length : null;
 }
 
+function hasExplicitSearchMode(params: SearchProductsParams): boolean {
+  return params.fuzzy !== undefined;
+}
+
 function mergeByEan(
   exact: ProductResponse[],
   fuzzy: ProductResponse[],
@@ -49,21 +53,15 @@ function mergeByEan(
  * Searches exactly first and tops the result up with fuzzy matches when the
  * exact pass comes back nearly empty, so a typo still finds something without
  * costing ranking quality on the queries that already work.
- *
- * Only an omitted `fuzzy` opts into that behaviour; an explicit value of either
- * kind is the caller stating what they want, so it is forwarded untouched.
  */
 export async function searchProductsWithFuzzyFallback(
   params: SearchProductsParams,
 ): Promise<{ data: unknown }> {
-  if (params.fuzzy !== undefined) return fetchProducts(params);
+  if (hasExplicitSearchMode(params)) return fetchProducts(params);
 
   const exact = await fetchProducts({ ...params, fuzzy: false });
   const exactCount = countProducts(exact.data);
   const effectiveLimit = params.limit ?? UPSTREAM_DEFAULT_SEARCH_LIMIT;
-
-  // Upstream already truncated the page to `limit`, so a small limit can never
-  // reach the flat threshold and would retry on an already-full page.
   const fallbackThreshold = Math.min(FUZZY_FALLBACK_THRESHOLD, effectiveLimit);
 
   if (exactCount === null || exactCount >= fallbackThreshold) {

--- a/frontend/src/lib/cijene-api/utils/product-search-fallback.ts
+++ b/frontend/src/lib/cijene-api/utils/product-search-fallback.ts
@@ -62,8 +62,13 @@ export async function searchProductsWithFuzzyFallback(
 
   const exact = await fetchProducts({ ...params, fuzzy: false });
   const exactCount = countProducts(exact.data);
+  const effectiveLimit = params.limit ?? UPSTREAM_DEFAULT_LIMIT;
 
-  if (exactCount === null || exactCount >= FUZZY_FALLBACK_THRESHOLD) {
+  // Upstream already truncated the page to `limit`, so a small limit can never
+  // reach the flat threshold and would retry on an already-full page.
+  const fallbackThreshold = Math.min(FUZZY_FALLBACK_THRESHOLD, effectiveLimit);
+
+  if (exactCount === null || exactCount >= fallbackThreshold) {
     return exact;
   }
 
@@ -81,7 +86,7 @@ export async function searchProductsWithFuzzyFallback(
       products: mergeByEan(
         exactParsed.data.products,
         fuzzyParsed.data.products,
-        params.limit ?? UPSTREAM_DEFAULT_LIMIT,
+        effectiveLimit,
       ),
     },
   };

--- a/frontend/src/lib/cijene-api/utils/product-search-fallback.ts
+++ b/frontend/src/lib/cijene-api/utils/product-search-fallback.ts
@@ -15,6 +15,9 @@ import { buildQueryString } from "@/utils/generic";
  */
 const FUZZY_FALLBACK_THRESHOLD = 10;
 
+/** Upstream matches on trigrams, which shorter queries cannot produce. */
+const MIN_FUZZY_QUERY_LENGTH = 3;
+
 const searchResultCountSchema = z.object({ products: z.array(z.unknown()) });
 
 function fetchProducts(params: SearchProductsParams) {
@@ -29,6 +32,10 @@ function countProducts(data: unknown): number | null {
 
 function hasExplicitSearchMode(params: SearchProductsParams): boolean {
   return params.fuzzy !== undefined;
+}
+
+function canFuzzyMatch(query: string): boolean {
+  return query.trim().length >= MIN_FUZZY_QUERY_LENGTH;
 }
 
 function mergeByEan(
@@ -64,9 +71,8 @@ export async function searchProductsWithFuzzyFallback(
   const effectiveLimit = params.limit ?? UPSTREAM_DEFAULT_SEARCH_LIMIT;
   const fallbackThreshold = Math.min(FUZZY_FALLBACK_THRESHOLD, effectiveLimit);
 
-  if (exactCount === null || exactCount >= fallbackThreshold) {
-    return exact;
-  }
+  if (exactCount === null || exactCount >= fallbackThreshold) return exact;
+  if (!canFuzzyMatch(params.q)) return exact;
 
   const fuzzy = await fetchProducts({ ...params, fuzzy: true }).catch(
     () => null,

--- a/frontend/src/lib/cijene-api/utils/product-search-fallback.ts
+++ b/frontend/src/lib/cijene-api/utils/product-search-fallback.ts
@@ -34,12 +34,17 @@ function mergeByEan(
   fuzzy: ProductResponse[],
   limit: number,
 ): ProductResponse[] {
-  const alreadyMatched = new Set(exact.map((product) => product.ean));
+  const seen = new Set(exact.map((product) => product.ean));
+  const merged = [...exact];
 
-  return [
-    ...exact,
-    ...fuzzy.filter((product) => !alreadyMatched.has(product.ean)),
-  ].slice(0, limit);
+  for (const product of fuzzy) {
+    if (seen.has(product.ean)) continue;
+
+    seen.add(product.ean);
+    merged.push(product);
+  }
+
+  return merged.slice(0, limit);
 }
 
 /**

--- a/frontend/src/lib/cijene-api/utils/product-search-fallback.ts
+++ b/frontend/src/lib/cijene-api/utils/product-search-fallback.ts
@@ -46,11 +46,14 @@ function mergeByEan(
  * Searches exactly first and tops the result up with fuzzy matches when the
  * exact pass comes back nearly empty, so a typo still finds something without
  * costing ranking quality on the queries that already work.
+ *
+ * Only an omitted `fuzzy` opts into that behaviour; an explicit value of either
+ * kind is the caller stating what they want, so it is forwarded untouched.
  */
 export async function searchProductsWithFuzzyFallback(
   params: SearchProductsParams,
 ): Promise<{ data: unknown }> {
-  if (params.fuzzy) return fetchProducts(params);
+  if (params.fuzzy !== undefined) return fetchProducts(params);
 
   const exact = await fetchProducts({ ...params, fuzzy: false });
   const exactCount = countProducts(exact.data);

--- a/frontend/src/lib/cijene-api/utils/product-search-fallback.ts
+++ b/frontend/src/lib/cijene-api/utils/product-search-fallback.ts
@@ -5,6 +5,7 @@ import {
   SearchProductsParams,
   productSearchResponseSchema,
 } from "@/lib/cijene-api/schemas";
+import { UPSTREAM_DEFAULT_SEARCH_LIMIT } from "@/constants/products";
 import { buildQueryString } from "@/utils/generic";
 
 /**
@@ -13,9 +14,6 @@ import { buildQueryString } from "@/utils/generic";
  * exact returns almost nothing: https://github.com/senko/cijene-api/issues/65
  */
 const FUZZY_FALLBACK_THRESHOLD = 10;
-
-/** Upstream's own default when `limit` is omitted. */
-const UPSTREAM_DEFAULT_LIMIT = 20;
 
 const searchResultCountSchema = z.object({ products: z.array(z.unknown()) });
 
@@ -62,7 +60,7 @@ export async function searchProductsWithFuzzyFallback(
 
   const exact = await fetchProducts({ ...params, fuzzy: false });
   const exactCount = countProducts(exact.data);
-  const effectiveLimit = params.limit ?? UPSTREAM_DEFAULT_LIMIT;
+  const effectiveLimit = params.limit ?? UPSTREAM_DEFAULT_SEARCH_LIMIT;
 
   // Upstream already truncated the page to `limit`, so a small limit can never
   // reach the flat threshold and would retry on an already-full page.


### PR DESCRIPTION
## Walkthrough

Implements all 7 findings from the pre-production multi-tool review of `dev` vs `main` (CodeRabbit, Codex `gpt-5.6-sol` high, and 3 Claude Sonnet reviewers; Cursor was out of usage). The consolidated triage doc lives at `reviews/REVIEW-2026-07-24-BY-AREA.html`, which is gitignored.

Six of the seven findings are in `product-search-fallback.ts`, the module added by #101, which no tool had reviewed before. This PR gates **#100** (`dev` -> `main`).

## The important one: #101's feature was nearly disabled

Codex flagged that an explicit `fuzzy=false` still received merged fuzzy results, breaking the parameter's exact-search contract. The obvious fix (short-circuit on any explicit `fuzzy`) turned out to **silently disable the whole top-up feature**, because:

- upstream (`senko/cijene-api`, `service/routers/v1.py`) declares `fuzzy: bool = Query(False, ...)`, so omitted and `false` mean the same thing there;
- both app callers were sending `fuzzy: false`;
- `buildQueryString` serializes `false` (it only skips `undefined`), so `?fuzzy=false` really was going over the wire and relying on falling through into the top-up.

Resolved by having the callers omit the parameter instead. The three states are now genuinely distinct:

| Request | Behaviour |
| --- | --- |
| `fuzzy` omitted | exact search, topped up with fuzzy when exact returns under the threshold |
| `fuzzy=true` | pure fuzzy search |
| `fuzzy=false` | strict exact search |

Verified against the live upstream OpenAPI spec: `limit` defaults to **20** (min 1, max 100), and issue [#65](https://github.com/senko/cijene-api/issues/65) ("Fuzzy search gives worse results than non fuzzy") is still open, which is what justifies the top-up approach at all.

## Changes

| Commit | Finding | Summary |
| --- | --- | --- |
| `336ad1f` + `1f3d054` | 1 (Major, CX) | Honour an explicit `fuzzy=false` as exact-only, and drop `fuzzy: false` from both caller hooks so the app keeps its top-up. Guard extracted to `hasExplicitSearchMode`. |
| `f58c502` | 2 (Minor, CR) | `mergeByEan` now adds each accepted fuzzy EAN to the `seen` set, so a repeated EAN inside the fuzzy page cannot survive. |
| `379a72f` | 3 (Minor, CR+CX+CC) | Fallback threshold is `min(FUZZY_FALLBACK_THRESHOLD, effectiveLimit)`, so a request with `limit` under 10 no longer fires a wasted second upstream call on an already-full page. |
| `71694e6` | 6 (Nit, CC) | `UPSTREAM_DEFAULT_SEARCH_LIMIT` moved into `constants/products.ts` beside `PRODUCT_SEARCH_LIMIT`; value confirmed against upstream's spec. |
| `2bb2377` | 7 (Nit, CC) | Skip the fuzzy retry below `MIN_FUZZY_QUERY_LENGTH`. Upstream's own exact-search code notes words under three characters produce no trigrams. Guards the retry only, so short exact searches are unaffected. |
| `47943e6` | 5 (Minor, CR+CC) | `fetchAuthToken` now captures status 500 and above to Sentry. Below 500 stays silent, since an unauthenticated 401 is normal. Return contract unchanged. |
| `81b5caa` | 4 (Minor, CC+CR) | `"packageManager": "pnpm@11.9.0"` so Netlify previews cannot silently install with a pnpm whose `minimumReleaseAge` default is 0. |

## Notes for reviewers

- **Finding 2 is hardening, not a live bug.** Upstream builds its response map keyed by `product.id`, so a duplicate EAN inside a single page is effectively impossible today. CodeRabbit called it a bug and a Claude reviewer called it clean; the code is correct either way, so it is fixed rather than argued.
- **Finding 3 does not change app behaviour.** Both callers pass `limit: 100`, so `min(10, 100)` is still 10. It matters for direct calls to the proxy with a small limit.
- Both caller hooks had to change together: they deliberately send identical params so results and facets share one React Query cache entry. Expect one cold cache miss after deploy.
- The `packageManager` pin is only safe because CI's `pnpm/action-setup` was pinned to `11.9.0` earlier on this branch; the action hard-errors when the two disagree. pnpm 10+ manages this automatically, so a newer local pnpm will switch to 11.9.0 inside this repo. Both use lockfile 9.0, so no lockfile churn.

## Rejected after verification

Three tool findings were checked against the code and dismissed rather than fixed, recorded in the triage doc so they are not re-raised:

- **CR major, "validate every response with the product schema"** - `route.ts` already wraps every call in `withCijeneRoute(..., productSearchResponseSchema, ...)`, which `safeParse`s and returns 502 on failure. Validating twice adds nothing.
- **CR major, "`token.ts` can reject"** - verified in the installed `better-auth` and `@better-fetch/fetch` sources that `$fetch` never sets `throw: true`, so HTTP errors return `{data, error}`. Real network rejections still reach `requestFreshToken`'s existing `try/catch`. Codex independently rated `lib/auth` CLEAN.
- **CR minor on #100, "bump via pnpm"** - Dependabot regenerated the lockfile in the same commit, so manifest and lockfile were already in sync.

## Estimated code review effort

🟢 **2 (Simple)** | ~20 minutes. Six small, well-scoped edits. The one worth real attention is the `fuzzy` semantics change and its two caller updates.

## Verification

`prettier --check src` passes, `tsc --noEmit` is clean, and `eslint src` reports 0 errors. After deploy to dev: a normal search still returns results, a typo'd query still finds something, `?fuzzy=false` returns only true matches, `?limit=5` makes a single upstream call, and a 1-2 character query does not trigger a fuzzy retry.
