### PR TITLE
chore(deps): Bump lombok and Sentry, hold springdoc at 2.2.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,10 +26,9 @@ updates:
           - "minor"
           - "patch"
     ignore:
-      # springdoc 3.x requires Spring Boot 4. Drop this once the Boot 4 migration lands.
+      # springdoc tracks the Spring Boot line it was built against, so Boot 3.1.x
+      # pairs with 2.2.x only. Drop this once the Boot 4 migration lands.
       - dependency-name: "org.springdoc:springdoc-openapi-starter-webmvc-ui"
-        update-types:
-          - "version-update:semver-major"
 
   # GitHub Actions workflows
   - package-ecosystem: "github-actions"

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -73,7 +73,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.30</version>
+			<version>1.18.46</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -96,7 +96,7 @@
 		<dependency>
 			<groupId>io.sentry</groupId>
 			<artifactId>sentry-spring-boot-starter-jakarta</artifactId>
-			<version>8.16.0</version>
+			<version>8.50.1</version>
 		</dependency>
 	</dependencies>
 
@@ -112,7 +112,7 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
-							<version>1.18.30</version>
+							<version>1.18.46</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>


### PR DESCRIPTION
## Walkthrough

Takes the two safe halves of the backend group Dependabot proposed in #104, and leaves out its springdoc bump.

## Changes

| File | Summary |
| --- | --- |
| `backend/pom.xml` | `org.projectlombok:lombok` **1.18.30 to 1.18.46** (both the dependency and the `annotationProcessorPaths` entry), and `io.sentry:sentry-spring-boot-starter-jakarta` **8.16.0 to 8.50.1**. |
| `.github/dependabot.yml` | Widen the springdoc ignore from `semver-major` only to every update type. |

## Why springdoc is excluded

springdoc publishes a version line per Spring Boot line, and each release declares the Boot it was built against:

| springdoc | built against Boot | matches this project's 3.1.0 |
| --- | --- | --- |
| 2.2.0 (kept) | 3.1.2 | yes |
| 2.8.17 (in #104) | 3.5.13 | no |

Because the POM inherits `spring-boot-starter-parent:3.1.0`, Spring's BOM wins the version resolution, so springdoc 2.8 would still compile. The risk is runtime: it may call Spring APIs added after 3.1 and throw on `/v3/api-docs` or Swagger UI. With no backend tests, CI would stay green and the failure would surface in production instead.

The previous ignore only covered majors, so this **minor** bump slipped through and would have quietly undone the deliberate 2.2.0 pin. It now covers every update type, and should be dropped as part of the Spring Boot 4 migration (#71), at which point springdoc moves to 3.x.

## Why the other two are safe

**lombok** compile-verifies through the annotation processor, so a green build is strong evidence here. The changelog shows no generated-code changes affecting the annotations in use (`@Data`, `@Builder`, `@RequiredArgsConstructor`, `@Slf4j`, `@Getter`, `@Setter`, `@NoArgsConstructor`, `@AllArgsConstructor`, `@Value`, `@NonNull`). The codebase has no `record` types and no `lombok.config`, so 1.18.34's "`@lombok.Generated` by default" change is a no-op. Worth noting 1.18.30 was the *first* release with JDK 21 support, so this moves off the roughest one.

**Sentry** is configured declaratively only, with no custom Sentry Java code anywhere in `src/main/java`. None of the five configured keys (`sentry.dsn`, `sentry.environment`, `sentry.traces-sample-rate`, `sentry.send-default-pii`, `sentry.debug`) was renamed, deprecated or removed across the range, and Boot 3.x support was never dropped. The breaking entries in that span are Android-only, Spotlight, OkHttp or scope-mutation related, none of which apply here.

## Verification

Backend CI proves compilation only, since there are no tests. After deploying to dev, smoke-test `/api-docs` and confirm Sentry still receives events.

Closes #104.
