### PR TITLE
chore(deps): Match @types/node to the runtime and cap the TypeScript range

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,7 +65,7 @@
     "@eslint/eslintrc": "^3",
     "@openapitools/openapi-generator-cli": "^2.25.2",
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^25",
+    "@types/node": "^24.13.3",
     "@types/pg": "^8.20.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
@@ -79,6 +79,6 @@
     "sharp": "^0.35.2",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^6.0.3"
+    "typescript": "~6.0.3"
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -168,8 +168,8 @@ importers:
         specifier: ^4
         version: 4.3.2
       '@types/node':
-        specifier: ^25
-        version: 25.9.5
+        specifier: ^24.13.3
+        version: 24.13.3
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
@@ -202,7 +202,7 @@ importers:
         version: 9.5.11(browserslist@4.28.6)(typescript@6.0.3)
       sharp:
         specifier: ^0.35.2
-        version: 0.35.3(@types/node@25.9.5)
+        version: 0.35.3(@types/node@24.13.3)
       tailwindcss:
         specifier: ^4
         version: 4.3.2
@@ -210,7 +210,7 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       typescript:
-        specifier: ^6.0.3
+        specifier: ~6.0.3
         version: 6.0.3
 
 packages:
@@ -2627,6 +2627,9 @@ packages:
 
   '@types/node@20.19.43':
     resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
+
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
   '@types/node@25.9.5':
     resolution: {integrity: sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==}
@@ -5521,6 +5524,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
@@ -7941,6 +7947,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/node@25.9.5':
     dependencies:
       undici-types: 7.24.6
@@ -9697,7 +9707,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.9.5
+      '@types/node': 24.13.3
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -10644,7 +10654,7 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
-  sharp@0.35.3(@types/node@25.9.5):
+  sharp@0.35.3(@types/node@24.13.3):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
@@ -10675,7 +10685,7 @@ snapshots:
       '@img/sharp-win32-arm64': 0.35.3
       '@img/sharp-win32-ia32': 0.35.3
       '@img/sharp-win32-x64': 0.35.3
-      '@types/node': 25.9.5
+      '@types/node': 24.13.3
 
   shebang-command@2.0.0:
     dependencies:
@@ -11047,6 +11057,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici-types@7.18.2: {}
 
   undici-types@7.24.6: {}
 


### PR DESCRIPTION
Changes:
- Move @types/node from `^25` to `^24.13.3`
- Narrow typescript from `^6.0.3` to `~6.0.3`

@types/node majors track the Node major they describe, and this project runs
Node 24 in CI and in the Docker image. It was pinned to `^25`, a short-lived
Current-only line that reached end of life on 2026-06-01 and was never the
runtime here, so the compiler was being told about APIs that do not exist at
run time. That mismatch is invisible to tsc by construction.

typescript-eslint 8.64 declares support for `>=4.8.4 <6.1.0`, and the caret
range would have let a future 6.1 install straight past that ceiling without
review. The tilde keeps 6.0.x patches flowing and leaves the 6.1 decision to a
Dependabot PR.

Notes:
- Both flagged by a full version-compatibility audit of the stack.
- `eslint-config-next` is one release behind `next` (16.2.2 against 16.2.11); the pending frontend group PR already carries that bump, so it is deliberately not touched here to avoid a conflict.

Both items came out of a full version-compatibility audit run across the frontend, backend, Docker images and CI actions.

## Verification

Locally on this branch: `next typegen` succeeds, `tsc --noEmit` is clean, `prettier --check src` is clean, and `eslint src` reports 0 errors.