### PR TITLE
fix(ui): Share one sort select and stop chain price badges appearing with no marked row

### DIFF
--- a/frontend/src/app/(user)/shopping-lists/[id]/components/stores/shopping-list-stores-list.tsx
+++ b/frontend/src/app/(user)/shopping-lists/[id]/components/stores/shopping-list-stores-list.tsx
@@ -41,8 +41,7 @@ export default function ShoppingListStoreSummary({
       : "products";
   });
 
-  function handleOptimizeChange(value: string) {
-    const mode = value as StoreOptimizeMode;
+  function handleOptimizeChange(mode: StoreOptimizeMode) {
     setOptimizeBy(mode);
     setStoreOptimizeMode(mode);
   }

--- a/frontend/src/app/(user)/shopping-lists/[id]/components/stores/store-optimize-select.tsx
+++ b/frontend/src/app/(user)/shopping-lists/[id]/components/stores/store-optimize-select.tsx
@@ -1,42 +1,31 @@
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import ComingSoonBadge from "@/components/custom/common/coming-soon-badge";
+import SortSelect, {
+  type ISortSelectOption,
+} from "@/components/custom/common/sort-select";
+import type { StoreOptimizeMode } from "@/app/(user)/shopping-lists/utils/shopping-list-utils";
+
+const OPTIMIZE_OPTIONS: ISortSelectOption[] = [
+  { value: "products", label: "Broj proizvoda" },
+  { value: "basket", label: "Najjeftinija košarica" },
+  { value: "total", label: "Zasebnim proizvodima" },
+  { value: "distance", label: "Udaljenost", comingSoon: true },
+];
 
 interface IStoreOptimizeSelectProps {
-  value: string;
-  onValueChange: (value: string) => void;
+  value: StoreOptimizeMode;
+  onValueChange: (mode: StoreOptimizeMode) => void;
 }
 
+/** Picks which store chains lead the list for a shopping list. */
 export default function StoreOptimizeSelect({
   value,
   onValueChange,
 }: IStoreOptimizeSelectProps) {
   return (
-    <div className="flex flex-wrap items-center justify-end gap-2">
-      <span className="text-sm text-muted-foreground">Optimiziraj po</span>
-
-      <Select value={value} onValueChange={onValueChange}>
-        <SelectTrigger className="w-full sm:w-60 bg-white" size="sm">
-          <SelectValue />
-        </SelectTrigger>
-
-        <SelectContent>
-          <SelectItem value="products">Broj proizvoda</SelectItem>
-          <SelectItem value="basket">Najjeftinija košarica</SelectItem>
-          <SelectItem value="total">Zasebnim proizvodima</SelectItem>
-          <SelectItem value="distance" disabled>
-            <span className="flex items-center gap-2">
-              Udaljenost
-              <ComingSoonBadge />
-            </span>
-          </SelectItem>
-        </SelectContent>
-      </Select>
-    </div>
+    <SortSelect
+      label="Optimiziraj po:"
+      value={value}
+      onValueChange={onValueChange}
+      options={OPTIMIZE_OPTIONS}
+    />
   );
 }

--- a/frontend/src/app/(user)/shopping-lists/[id]/utils/store-chain-extremes.ts
+++ b/frontend/src/app/(user)/shopping-lists/[id]/utils/store-chain-extremes.ts
@@ -1,11 +1,17 @@
 import { ShoppingListItemDto } from "@/lib/api/types";
 import { ProductResponse } from "@/lib/cijene-api/schemas";
+import {
+  getPriceExtreme,
+  type PriceExtreme,
+} from "@/app/products/utils/product-utils";
 
-// How many list products hit their extreme average price at each chain.
+// How many list products hit their extreme average price at each chain, judged by
+// the same rule the price cells use, so a chain never earns a badge without a
+// marked row behind it.
 function countChainsAtExtreme(
   productsData: ProductResponse[],
   activeItems: ShoppingListItemDto[],
-  pickExtreme: (prices: number[]) => number,
+  extreme: NonNullable<PriceExtreme>,
 ): Map<string, number> {
   const counts = new Map<string, number>();
 
@@ -20,10 +26,14 @@ function countChainsAtExtreme(
       .filter((price) => !isNaN(price));
     if (prices.length === 0) return;
 
-    const extreme = pickExtreme(prices);
+    const min = Math.min(...prices);
+    const max = Math.max(...prices);
 
     product.chains.forEach((chain) => {
-      if (parseFloat(chain.avg_price) !== extreme) return;
+      if (getPriceExtreme(parseFloat(chain.avg_price), min, max) !== extreme) {
+        return;
+      }
+
       counts.set(chain.chain, (counts.get(chain.chain) ?? 0) + 1);
     });
   });
@@ -35,18 +45,12 @@ export function countCheapestByChain(
   productsData: ProductResponse[],
   activeItems: ShoppingListItemDto[],
 ): Map<string, number> {
-  return countChainsAtExtreme(productsData, activeItems, (prices) =>
-    Math.min(...prices),
-  );
+  return countChainsAtExtreme(productsData, activeItems, "min");
 }
 
 export function findHighestPriceStores(
   productsData: ProductResponse[],
   activeItems: ShoppingListItemDto[],
 ): Set<string> {
-  const counts = countChainsAtExtreme(productsData, activeItems, (prices) =>
-    Math.max(...prices),
-  );
-
-  return new Set(counts.keys());
+  return new Set(countChainsAtExtreme(productsData, activeItems, "max").keys());
 }

--- a/frontend/src/app/products/[id]/components/product-chain-sort-select.tsx
+++ b/frontend/src/app/products/[id]/components/product-chain-sort-select.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import ComingSoonBadge from "@/components/custom/common/coming-soon-badge";
+import SortSelect, {
+  type ISortSelectOption,
+} from "@/components/custom/common/sort-select";
 import type { ProductChainSortMode } from "@/app/products/utils/product-chain-sort";
+
+const SORT_OPTIONS: ISortSelectOption[] = [
+  { value: "stores", label: "Trgovinama" },
+  { value: "price", label: "Cijeni" },
+  { value: "distance", label: "Udaljenosti", comingSoon: true },
+];
 
 interface IProductChainSortSelectProps {
   value: ProductChainSortMode;
@@ -21,28 +22,11 @@ export default function ProductChainSortSelect({
   onValueChange,
 }: IProductChainSortSelectProps) {
   return (
-    <div className="flex flex-wrap items-center justify-end gap-2">
-      <span className="text-sm text-muted-foreground">Sortiraj po</span>
-
-      <Select
-        value={value}
-        onValueChange={(mode) => onValueChange(mode as ProductChainSortMode)}
-      >
-        <SelectTrigger className="w-full sm:w-60 bg-white" size="sm">
-          <SelectValue />
-        </SelectTrigger>
-
-        <SelectContent>
-          <SelectItem value="stores">Trgovinama</SelectItem>
-          <SelectItem value="price">Cijeni</SelectItem>
-          <SelectItem value="distance" disabled>
-            <span className="flex items-center gap-2">
-              Udaljenosti
-              <ComingSoonBadge />
-            </span>
-          </SelectItem>
-        </SelectContent>
-      </Select>
-    </div>
+    <SortSelect
+      label="Optimiziraj po:"
+      value={value}
+      onValueChange={onValueChange}
+      options={SORT_OPTIONS}
+    />
   );
 }

--- a/frontend/src/components/custom/common/sort-select.tsx
+++ b/frontend/src/components/custom/common/sort-select.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import ComingSoonBadge from "@/components/custom/common/coming-soon-badge";
+
+export interface ISortSelectOption {
+  value: string;
+  label: string;
+  comingSoon?: boolean;
+}
+
+interface ISortSelectProps<TMode extends string> {
+  label: string;
+  value: TMode;
+  onValueChange: (mode: TMode) => void;
+  options: readonly ISortSelectOption[];
+}
+
+/** Leading label and dropdown for ordering a list, shared by every list that offers one. */
+export default function SortSelect<TMode extends string>({
+  label,
+  value,
+  onValueChange,
+  options,
+}: ISortSelectProps<TMode>) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="shrink-0 text-sm text-muted-foreground">{label}</span>
+
+      <Select
+        value={value}
+        onValueChange={(mode) => onValueChange(mode as TMode)}
+      >
+        {/* The trigger keeps the primitive's w-fit so its label never clips, and
+            min-h beats the primitive's own height where a plain h- utility loses. */}
+        <SelectTrigger className="min-h-10 min-w-52 bg-white">
+          <SelectValue />
+        </SelectTrigger>
+
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem
+              key={option.value}
+              value={option.value}
+              disabled={option.comingSoon}
+            >
+              {option.comingSoon ? (
+                <span className="flex items-center gap-2">
+                  {option.label}
+                  <ComingSoonBadge />
+                </span>
+              ) : (
+                option.label
+              )}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}


### PR DESCRIPTION
Two unrelated fixes on the shopping list and product detail pages, one layout and one correctness.

## 1. Shared sort select (`5d96053`)

`product-chain-sort-select.tsx` ("Sortiraj po", product detail) and `store-optimize-select.tsx` ("Optimiziraj po", shopping list detail) carried byte-identical wrapper markup, so the same three layout problems existed twice. They now both render a new `components/custom/common/sort-select.tsx` and are reduced to their option lists.

| | before | after |
| --- | --- | --- |
| alignment | `justify-end` | left |
| mobile | `w-full` dropdown wrapping below the label | label and dropdown inline |
| height | `size="sm"`, `h-8` | `min-h-10`, matching the Filteri button |

Three non-obvious details:

- The trigger keeps the primitive's `w-fit`. `SelectValue` carries `line-clamp-1`, whose `overflow: hidden` collapses the flex item's automatic minimum size, so **any** fixed width lets flexbox shrink the trigger below its own text and ellipsise the option. `min-w-52` is only a floor, so the control does not resize as options change.
- The height override is `min-h-10`, not `h-10`. `select.tsx` sizes itself with `data-[size=default]:h-9`, whose attribute selector out-specifies a plain `h-10` utility, so the override would silently lose. `min-height` beats `height` regardless of specificity, and `min-h-*` is already how `MultiSelectTrigger` sizes itself.
- `flex-wrap` on the row is an overflow valve below roughly 320px, where the label and a 13rem dropdown stop fitting side by side.

The select is generic over its mode type, which removed the `as ProductChainSortMode` / `as StoreOptimizeMode` casts from both call sites and from `shopping-list-stores-list.tsx`. `components/ui/select.tsx` is untouched.

## 2. Chain price badges could appear with no marked row (`42ad71c`)

A store chain card could show both the cheapest and the most expensive arrow while not one of its products was highlighted.

Two different rules were deciding the same question. The price cells go through `getPriceExtreme`, which returns `null` when `min === max`, so a product priced the same at every chain renders neutrally. `countChainsAtExtreme` had no such guard:

```ts
const extreme = pickExtreme(prices);          // Math.min(...) or Math.max(...)
product.chains.forEach((chain) => {
  if (parseFloat(chain.avg_price) !== extreme) return;
  counts.set(chain.chain, (counts.get(chain.chain) ?? 0) + 1);
});
```

For a uniformly priced product `min` and `max` are both that price, so **every** chain carrying it was counted as both cheapest and most expensive, while no row lit up. One such product on a list is enough to give an unrelated chain both arrows.

`countChainsAtExtreme` now calls `getPriceExtreme` too, taking the wanted extreme as a `"min"` or `"max"` argument instead of a `pickExtreme` callback. One rule drives both the badge and the cell, so a badge cannot appear without a marked row behind it.

Side effect: `countCheapestByChain` also ranks chains in the "Zasebnim proizvodima" mode, so that ordering shifts slightly. Uniformly priced products no longer pad every chain's cheapest count, which is the intended reading of the metric.

## Known gap, not fixed here

The same mismatch exists in the opposite direction. The badges count only unchecked items (`activeItems`), but the table renders every item including checked ones and still colours their price. Ticking off the product behind a badge therefore leaves a struck-through but still green row with no badge.

## Verification

`prettier --check`, `tsc --noEmit` and `eslint` are clean. Not verified in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
