### PR TITLE
docs: Align the brand graph and the nav regression checklist with what shipped

### DIFF
--- a/docs/BRAND.md
+++ b/docs/BRAND.md
@@ -60,15 +60,21 @@ flowchart TD
     subgraph Shared[scripts/lib shared helpers]
         L1[cart-source.mjs<br/>renderCart / cartOnSquare]
         L2[cart-frames.mjs<br/>easings + per-frame cart]
+        L3[brand.mjs<br/>brand green]
+        L4[srgb.mjs<br/>sRGB tagging]
     end
     S1 --> L1
     S2 --> L2
+    L3 --> L2
     G1[generate-logos.mjs]
     G2[generate-pwa-icons.mjs]
     G3[generate-ios-splash.mjs]
     G4[generate-shortcut-icons.mjs]
-    L1 --> G2 & G3
+    L1 --> G1 & G2 & G3
+    L1 -.->|ROOT path only| G4
     L2 --> G1
+    L3 --> G1 & G4
+    L4 --> G1 & G2 & G3 & G4
     S2 --> G1
     S3 --> G1 & G3
     Lucide[lucide-react nav icons<br/>not a brand source] --> G4

--- a/docs/MOBILE-NAV.md
+++ b/docs/MOBILE-NAV.md
@@ -1078,7 +1078,7 @@ Carried over from the build spec this feature was written against, which is why 
 - [ ] Escape closes it
 - [ ] Pretraži sits at the bottom whatever the sheet's height, and Enter in the field submits
 - [ ] Pretraži is disabled when the field is empty and when it matches the current query, with no flash after clearing
-- [ ] Submitting from another route lands on the products list with the sheet still open
+- [ ] Submitting from another route lands on the products list and closes the sheet
 - [ ] Scanning a barcode closes it
 - [ ] Popusti is present, disabled, badged, and enabled for an admin
 
@@ -1090,7 +1090,7 @@ Carried over from the build spec this feature was written against, which is why 
 - [ ] Picking a facet on the products list updates the URL and the list behind it, live, without closing the sheet
 - [ ] Picking a facet from another route navigates to the products list carrying both the facet and whatever was typed
 - [ ] Clearing the filters and then picking one option does not resurrect the cleared ones
-- [ ] Očisti filtere is present but disabled with no filters set, icon-only below `md` with a tooltip, labelled above it
+- [ ] Očisti filtere is present but disabled with no filters set, and its label remains visible below `md`
 - [ ] A facet's popover scrolls by touch
 
 ### Sheets and layers
@@ -1098,7 +1098,7 @@ Carried over from the build spec this feature was written against, which is why 
 - [ ] All three sheets end the same distance above the bar, and none covers it
 - [ ] Each sheet caps at 85% of the **dynamic** viewport, not 80% of the static one
 - [ ] The gap below the grab handle is 16px in all three, including the one with a hidden title
-- [ ] A modal sheet's scrim leaves the bar visible, and the bar is inert under it
+- [ ] A modal sheet's scrim covers the bar, leaving it inert underneath
 - [ ] The install instructions sheet shows its description, closes on an outside press, and has a visible close control
 - [ ] No sheet's own code sets a layer, a bottom padding or a safe-area value
 


### PR DESCRIPTION
Documentation corrections found while attempting a browser verification pass over the merged bottom-nav work.

**Read this first: the browser verification did not happen.** Codex `gpt-5.6-sol` was asked to drive Playwright through 37 runtime checks plus the full regression checklist. Chromium would not launch under its sandbox, so **all 37 came back `COULD-NOT-TEST`**. It did not fabricate results, which is the right call, but nothing in the merged branch has been runtime-verified. This PR therefore contains documentation only, and the runtime checks remain outstanding.

## What is actually in here

**`docs/BRAND.md`, the generator graph.** It omitted `lib/brand.mjs` and `lib/srgb.mjs`, the two shared helpers PR #131 introduced, so the diagram was stale by its own change. Added, with every edge checked against the real imports.

One edge needed care: `generate-shortcut-icons.mjs` does import from `cart-source.mjs`, but only `ROOT`, a path constant, not any cart rendering. Drawn as a plain edge it contradicted the table directly below, which calls that script "the one generator that does not start from the cart". It is now a labelled dashed edge.

**`docs/MOBILE-NAV.md`, three stale regression-checklist lines** that my own docs pass missed. The behaviour changed in the merged branch and the checklist still described the old contract:

| Line | Was | Now |
| --- | --- | --- |
| Submitting from another route | "with the sheet still open" | "and closes the sheet" |
| Očisti filtere | "icon-only below `md` with a tooltip" | "its label remains visible below `md`" |
| A modal sheet's scrim | "leaves the bar visible" | "covers the bar, leaving it inert underneath" |

## Two CodeRabbit comments from #131 are deliberately declined

**`cart/cart-rgb.svg` in the fresh-run order was reported wrong. It is not.** The claim was that `generate-logos.mjs` writes `cart/cart-r.svg` and `cart/white.svg`. Verified: `generate-logos.mjs:124` writes `cart-rgb.svg` through `markFile(`${name}.svg`)`, `lib/cart-source.mjs:14` reads that same path lazily inside `renderCart()`, and neither `cart-r.svg` nor `white.svg` exists on disk. The existing ordering note is accurate and unchanged.

**Default-exporting `pwaShortcuts` is declined.** AGENTS.md's "prefer default exports" is a component convention; every sibling in `constants/` (`navigation.ts`, `protected-routes.ts`, `gestures.ts`) uses named exports. Changing this one would make it the odd file out.

## Verification

Local gate clean: `tsc --noEmit`, `eslint src` at its 22-warning baseline with zero errors, and both `prettier --check` passes. No application code changed.
